### PR TITLE
Initialize monorepo with Next.js/Phaser skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Node
+node_modules
+.pnpm
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Mac
+.DS_Store
+
+# Build
+.next
+
+# Others
+.idea
+.vscode

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $*"
+  }
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"
+    exit 0
+  fi
+  if [ -f ~/.huskyrc ]; then
+    debug "sourcing ~/.huskyrc"
+    . ~/.huskyrc
+  fi
+  export readonly husky_skip_init=1
+  sh -e "$0" "$@"
+  exit $?
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# ハイスピードおつかいローグ
+
+Monorepo structure for the Highspeed Otsukai Rogue project.
+
+## Usage
+
+```bash
+pnpm install
+pnpm dev
+```
+
 ## ドキュメント
 - [ゲーム概要 (JA)](docs/game-overview-ja.md)
 - [実装ロードマップ (JA)](docs/implementation-roadmap-ja.md)

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+export default {
+  reactStrictMode: true,
+  eslint: { ignoreDuringBuilds: true }
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@web",
+  "private": true,
+  "dependencies": {
+    "next": "14",
+    "react": "18",
+    "react-dom": "18",
+    "phaser": "^3.70",
+    "tone": "^15",
+    "scribbletune": "^4"
+  }
+}

--- a/apps/web/src/game-wrapper.tsx
+++ b/apps/web/src/game-wrapper.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { bootGame } from '@/game';
+
+export default function GameWrapper() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (ref.current) bootGame(ref.current);
+  }, []);
+
+  return <div ref={ref} id="phaser-root" className="w-full h-full" />;
+}

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -1,0 +1,19 @@
+import dynamic from 'next/dynamic';
+import Head from 'next/head';
+
+// Avoid SSR for Phaser
+const Game = dynamic(() => import('@/game-wrapper'), { ssr: false });
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>ハイスピードおつかいローグ</title>
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+      </Head>
+      <main className="flex h-screen w-screen items-center justify-center bg-black">
+        <Game />
+      </main>
+    </>
+  );
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "highspeed-otsukai-rogue",
+  "private": true,
+  "packageManager": "pnpm@8",
+  "scripts": {
+    "dev": "pnpm --filter ./apps/web dev",
+    "build": "pnpm --filter ./apps/web build",
+    "lint": "eslint \"**/*.{ts,tsx}\" --fix",
+    "prepare": "husky install"
+  },
+  "devDependencies": {
+    "eslint": "^8",
+    "eslint-config-next": "latest",
+    "prettier": "^3",
+    "typescript": "^5",
+    "husky": "^9",
+    "lint-staged": "^15"
+  },
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "lint-staged": {
+    "**/*.{ts,tsx}": "eslint --fix"
+  }
+}

--- a/packages/game/package.json
+++ b/packages/game/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@game",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "phaser": "^3.70"
+  }
+}

--- a/packages/game/src/index.ts
+++ b/packages/game/src/index.ts
@@ -1,0 +1,14 @@
+import Phaser from 'phaser';
+import { GameScene } from './scenes/GameScene';
+
+export function bootGame(parent: HTMLElement) {
+  new Phaser.Game({
+    type: Phaser.AUTO,
+    width: 800,
+    height: 600,
+    parent,
+    backgroundColor: '#000000',
+    scene: [GameScene],
+    pixelArt: true
+  });
+}

--- a/packages/game/src/scenes/GameScene.ts
+++ b/packages/game/src/scenes/GameScene.ts
@@ -1,0 +1,14 @@
+import Phaser from 'phaser';
+
+export class GameScene extends Phaser.Scene {
+  constructor() { super('GameScene'); }
+
+  preload() {
+    // preload assets (placeholder)
+  }
+
+  create() {
+    // temporary text to verify rendering
+    this.add.text(400, 300, 'Hello Rogue!', { color: '#ffffff' }).setOrigin(0.5);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/game/*": ["packages/game/src/*"],
+      "@/ui/*": ["apps/web/src/components/*"],
+      "@/lib/*": ["apps/web/src/lib/*"]
+    },
+    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "target": "ES2020",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["apps", "packages"]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "apps/web/next.config.mjs", "use": "@vercel/next" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "apps/web/$1" }
+  ]
+}


### PR DESCRIPTION
## Summary
- set up monorepo layout using pnpm workspaces
- configure base TypeScript settings and Vercel deployment
- add Next.js app and Phaser game package
- provide husky pre-commit hook and lint-staged config

## Testing
- `pnpm install` *(fails: command not found)*
- `pnpm dev` *(fails: command not found)*
- `pnpm build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fb4b14ac88333a839a1b861a473dd