### PR TITLE
Implement Phaser bootstrap and Next.js scaffolding

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+declare module '@highspeed/game';
+
+// NOTE: This file should not be edited

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: false
+  },
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@highspeed/game": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "5.3.3",
+    "@types/react": "18.2.14",
+    "@types/node": "20.6.2"
+  }
+}

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -1,0 +1,5 @@
+import type { AppProps } from 'next/app';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+import { createGame } from '@highspeed/game';
+
+export default function Home() {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const game = createGame(containerRef.current);
+    return () => {
+      game.destroy(true);
+    };
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ width: '100%', height: '100vh', display: 'flex', justifyContent: 'center', alignItems: 'center' }}
+    />
+  );
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/e2e/basic.spec.ts
+++ b/e2e/basic.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('renders canvas', async ({ page }) => {
+  await page.goto('/');
+  const canvases = await page.locator('canvas');
+  await expect(canvases).toHaveCount(1);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "high-speed-errand-rogue",
+  "private": true,
+  "workspaces": ["apps/*", "packages/*"],
+  "scripts": {
+    "build": "npm run build -w @highspeed/game && npm run build -w web",
+    "dev": "npm run dev -w web",
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.40.1"
+  }
+}

--- a/packages/game/package.json
+++ b/packages/game/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@highspeed/game",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "phaser": "^3.70.0"
+  }
+}

--- a/packages/game/src/Game.ts
+++ b/packages/game/src/Game.ts
@@ -1,0 +1,21 @@
+import Phaser from 'phaser';
+
+export class MainScene extends Phaser.Scene {
+  constructor() {
+    super('main');
+  }
+
+  create() {
+    this.cameras.main.setBackgroundColor('#000000');
+  }
+}
+
+export function createGame(parent: HTMLElement | string): Phaser.Game {
+  return new Phaser.Game({
+    type: Phaser.AUTO,
+    width: 640,
+    height: 360,
+    parent,
+    scene: MainScene,
+  });
+}

--- a/packages/game/src/index.ts
+++ b/packages/game/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Game';

--- a/packages/game/tsconfig.json
+++ b/packages/game/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+    cwd: './',
+  },
+  testDir: './e2e',
+});


### PR DESCRIPTION
## Summary
- add Phaser bootstrap in packages/game
- scaffold Next.js app with GameCanvas on index page
- add Playwright smoke test for canvas rendering

## Testing
- `npm run dev` *(fails: next not found)*
- `npm run build` *(fails: cannot find module 'phaser')*
- `vercel build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fbf36f8b88333a7b8b0198fedecc9