### PR TITLE
Implement viewport scaling for Phaser 3 demo

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,7 +1,14 @@
 const config = {
   type: Phaser.AUTO,
-  width: 800,
-  height: 600,
+  width: 480,
+  height: 270,
+  parent: 'game-container',
+  scale: {
+    mode: Phaser.Scale.FIT,
+    autoCenter: Phaser.Scale.CENTER_BOTH,
+    width: 480,
+    height: 270
+  },
   scene: {
     preload,
     create,
@@ -14,11 +21,12 @@ function preload() {
 }
 
 function create() {
-  this.add.text(300, 280, 'Hello Phaser!', { fontSize: '32px', color: '#ffffff' }).setOrigin(0.5);
+  this.add.text(240, 135, 'Hello Phaser!', { fontSize: '32px', color: '#ffffff' }).setOrigin(0.5);
 }
 
 function update() {
   // game loop logic
 }
 
-new Phaser.Game(config);
+const game = new Phaser.Game(config);
+window.addEventListener('resize', () => game.scale.refresh());

--- a/index.html
+++ b/index.html
@@ -6,11 +6,24 @@
   <title>Phaser 3 Minimal</title>
   <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
   <style>
-    body { margin: 0; }
-    canvas { display: block; margin: 0 auto; }
+    html, body {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+    }
+    #game-container {
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+    canvas {
+      display: block;
+      margin: 0 auto;
+    }
   </style>
 </head>
 <body>
+  <div id="game-container"></div>
   <script src="game.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- scale Phaser canvas using a fixed 480x270 virtual resolution
- fill the browser window via Phaser's `FIT` scale mode
- center Hello Phaser! text with the new resolution

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6880803f9c048333b249afea9f97a397