### PR TITLE
Add GameState class

### DIFF
--- a/game-state.js
+++ b/game-state.js
@@ -1,0 +1,23 @@
+(function(global){
+  class GameState {
+    constructor() {
+      // Number of maze chunks the player has cleared
+      this.clearedMazes = 0;
+      // Placeholder for future expansion such as score or items
+      this.score = 0;
+    }
+
+    // Increase cleared maze count when player exits a maze
+    incrementMazeCount() {
+      this.clearedMazes += 1;
+    }
+
+    // Reset the game progress
+    reset() {
+      this.clearedMazes = 0;
+      this.score = 0;
+    }
+  }
+
+  global.GameState = GameState;
+})(typeof window !== 'undefined' ? window : global);

--- a/game.js
+++ b/game.js
@@ -1,3 +1,6 @@
+// Global state for tracking overall game progress
+const gameState = new GameState();
+
 const config = {
   type: Phaser.AUTO,
   width: 480,
@@ -22,6 +25,15 @@ function preload() {
 
 function create() {
   this.add.text(240, 135, 'Hello Phaser!', { fontSize: '32px', color: '#ffffff' }).setOrigin(0.5);
+  this.mazeText = this.add.text(10, 10, `Mazes Cleared: ${gameState.clearedMazes}`, {
+    fontSize: '16px',
+    color: '#ffffff'
+  });
+
+  this.input.keyboard.on('keydown-M', () => {
+    gameState.incrementMazeCount();
+    this.mazeText.setText(`Mazes Cleared: ${gameState.clearedMazes}`);
+  });
 }
 
 function update() {

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
 </head>
 <body>
   <div id="game-container"></div>
+  <script src="game-state.js"></script>
   <script src="game.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `game-state.js` providing `GameState` class for tracking cleared mazes
- load new script from `index.html`
- create a global `gameState` in `game.js` and display cleared maze count
- allow pressing **M** to increment the maze clear count

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6880877862c48333909d0a4ef4f5d171