### PR TITLE
Implement basic maze flow

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,8 +1,10 @@
 import GameState from './game-state.js';
 import HeroState from './hero_state.js';
 import CameraController from './camera.js';
+import { generateChunk } from './maze.js';
+import MazeManager from './maze_manager.js';
 
-// Global state for tracking overall game progress
+const TILE_SIZE = 32;
 const gameState = new GameState();
 
 const config = {
@@ -24,7 +26,7 @@ const config = {
 };
 
 function preload() {
-  // preload assets here (none for minimal setup)
+  // No assets yet
 }
 
 let hero;
@@ -32,18 +34,30 @@ let heroSprite;
 let cursors;
 let cameraController;
 let uiLayer;
+let mazeManager;
+let heroChunkObj;
+let heroPos = { x: 0, y: 0 };
 
 function create() {
   hero = new HeroState();
-
   this.worldLayer = this.add.container(0, 0);
-  heroSprite = this.add.rectangle(0, 0, 32, 32, 0x00ff00);
+
+  mazeManager = new MazeManager(this, gameState, TILE_SIZE);
+  heroSprite = this.add.rectangle(0, 0, TILE_SIZE, TILE_SIZE, 0x00ff00).setOrigin(0);
   this.worldLayer.add(heroSprite);
+
+  const firstChunk = generateChunk(0);
+  heroChunkObj = mazeManager.addChunk(firstChunk, 0, 0);
+  heroPos.x = firstChunk.entrance.x;
+  heroPos.y = firstChunk.entrance.y;
+  const pos = mazeManager.worldPos(heroChunkObj, heroPos.x, heroPos.y);
+  heroSprite.x = pos.x;
+  heroSprite.y = pos.y;
 
   uiLayer = this.add.container(0, 0);
   uiLayer.setScrollFactor(0);
 
-  this.cameras.main.setBounds(-500, -500, 1000, 1000);
+  this.cameras.main.setBounds(-1000, -1000, 2000, 2000);
   cameraController = new CameraController(this);
   cameraController.follow(heroSprite);
 
@@ -56,35 +70,59 @@ function create() {
   this.mazeText.setScrollFactor(0);
   uiLayer.add(this.mazeText);
 
-  this.input.keyboard.on('keydown-M', () => {
+  this.gameOverText = this.add.text(240, 135, 'GAME OVER', { fontSize: '32px', color: '#ff0000' }).setOrigin(0.5);
+  this.gameOverText.setScrollFactor(0);
+  this.gameOverText.visible = false;
+
+  this.gameOver = () => {
+    this.gameOverText.visible = true;
+    this.scene.pause();
+  };
+}
+
+function moveHero(dx, dy) {
+  const chunk = heroChunkObj.chunk;
+  const cell = chunk.tiles[heroPos.y][heroPos.x];
+  const dirMap = { '-1,0': 'W', '1,0': 'E', '0,-1': 'N', '0,1': 'S' };
+  const dir = dirMap[`${dx},${dy}`];
+  if (dir && cell.walls[dir]) return;
+
+  const nx = heroPos.x + dx;
+  const ny = heroPos.y + dy;
+  if (nx < 0 || ny < 0 || nx >= chunk.width || ny >= chunk.height) return;
+  heroPos.x = nx;
+  heroPos.y = ny;
+  const pos = mazeManager.worldPos(heroChunkObj, heroPos.x, heroPos.y);
+  heroSprite.x = pos.x;
+  heroSprite.y = pos.y;
+  hero.moveTo(heroSprite.x, heroSprite.y);
+
+  const newCell = chunk.tiles[heroPos.y][heroPos.x];
+  if (newCell.type === 'exit') {
     gameState.incrementMazeCount();
     this.mazeText.setText(`Mazes Cleared: ${gameState.clearedMazes}`);
-  });
-
-  this.input.keyboard.on('keydown-Q', () => {
-    cameraController.setZoom(Math.min(cameraController.camera.zoom + 0.1, 2), 100);
-  });
-
-  this.input.keyboard.on('keydown-E', () => {
-    cameraController.setZoom(Math.max(cameraController.camera.zoom - 0.1, 0.5), 100);
-  });
+    const nextChunk = generateChunk(gameState.clearedMazes);
+    const offsetX = heroChunkObj.x + chunk.width * TILE_SIZE;
+    const offsetY = heroChunkObj.y;
+    heroChunkObj = mazeManager.addChunk(nextChunk, offsetX, offsetY);
+    const startPos = mazeManager.worldPos(heroChunkObj, nextChunk.entrance.x, nextChunk.entrance.y);
+    heroPos.x = nextChunk.entrance.x;
+    heroPos.y = nextChunk.entrance.y;
+    heroSprite.x = startPos.x;
+    heroSprite.y = startPos.y;
+    cameraController.panTo(heroSprite.x, heroSprite.y, 400);
+  } else if (newCell.type === 'chest' || newCell.type === 'itemChest') {
+    newCell.rect.fillColor = 0x222222;
+  }
 }
 
 function update() {
-  const speed = hero.speed;
-  if (cursors.left.isDown) {
-    heroSprite.x -= speed * this.game.loop.delta / 1000;
-  } else if (cursors.right.isDown) {
-    heroSprite.x += speed * this.game.loop.delta / 1000;
-  }
+  if (Phaser.Input.Keyboard.JustDown(cursors.left)) moveHero.call(this, -1, 0);
+  else if (Phaser.Input.Keyboard.JustDown(cursors.right)) moveHero.call(this, 1, 0);
+  else if (Phaser.Input.Keyboard.JustDown(cursors.up)) moveHero.call(this, 0, -1);
+  else if (Phaser.Input.Keyboard.JustDown(cursors.down)) moveHero.call(this, 0, 1);
 
-  if (cursors.up.isDown) {
-    heroSprite.y -= speed * this.game.loop.delta / 1000;
-  } else if (cursors.down.isDown) {
-    heroSprite.y += speed * this.game.loop.delta / 1000;
-  }
-
-  hero.moveTo(heroSprite.x, heroSprite.y);
+  mazeManager.fadeOldChunks(heroChunkObj.chunk);
 }
 
 const game = new Phaser.Game(config);

--- a/maze_manager.js
+++ b/maze_manager.js
@@ -1,0 +1,71 @@
+export default class MazeManager {
+  constructor(scene, gameState, tileSize = 32) {
+    this.scene = scene;
+    this.gameState = gameState;
+    this.tileSize = tileSize;
+    this.chunks = [];
+  }
+
+  addChunk(chunk, x, y) {
+    const cont = this.scene.add.container(x, y);
+    for (let j = 0; j < chunk.height; j++) {
+      for (let i = 0; i < chunk.width; i++) {
+        const cell = chunk.tiles[j][i];
+        const color = this._colorFor(cell.type);
+        const rect = this.scene.add.rectangle(i * this.tileSize, j * this.tileSize,
+          this.tileSize, this.tileSize, color).setOrigin(0);
+        cont.add(rect);
+        cell.rect = rect;
+      }
+    }
+    chunk.container = cont;
+    this.chunks.push({ chunk, x, y });
+    return this.chunks[this.chunks.length - 1];
+  }
+
+  _colorFor(type) {
+    switch (type) {
+      case 'entrance':
+        return 0x008800;
+      case 'exit':
+        return 0xaa0000;
+      case 'chest':
+        return 0xffff00;
+      case 'itemChest':
+        return 0xff00ff;
+      default:
+        return 0x444444;
+    }
+  }
+
+  worldPos(chunkObj, cellX, cellY) {
+    return {
+      x: chunkObj.x + cellX * this.tileSize,
+      y: chunkObj.y + cellY * this.tileSize
+    };
+  }
+
+  fadeOldChunks(activeChunk) {
+    const threshold = 5000; // ms
+    for (const obj of this.chunks) {
+      obj.chunk.age += this.scene.game.loop.delta;
+      if (!obj.chunk.fading && obj.chunk !== activeChunk && obj.chunk.age > threshold) {
+        obj.chunk.fading = true;
+        this.scene.tweens.add({
+          targets: obj.chunk.container,
+          alpha: 0,
+          duration: 1000,
+          onComplete: () => {
+            obj.chunk.container.destroy();
+            obj.removed = true;
+            const idx = this.chunks.indexOf(obj);
+            if (idx !== -1) this.chunks.splice(idx, 1);
+            if (activeChunk === obj.chunk) {
+              this.scene.gameOver();
+            }
+          }
+        });
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add MazeManager for chunk rendering and fading
- implement maze spawn, traversal and extend in game.js

## Testing
- `node -e "require('./maze.js');"`
- `node -e "require('./maze_manager.js');"`

------
https://chatgpt.com/codex/tasks/task_e_6880961e0a308333821faf3f4504f48e