### PR TITLE
Implement basic maze flow

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,6 +1,7 @@
 import GameState from './game-state.js';
 import HeroState from './hero_state.js';
 import CameraController from './camera.js';
+import MazeManager from './maze_manager.js';
 
 // Global state for tracking overall game progress
 const gameState = new GameState();
@@ -30,24 +31,31 @@ function preload() {
 let hero;
 let heroSprite;
 let cursors;
+let wasdKeys;
 let cameraController;
 let uiLayer;
+let mazeManager;
 
 function create() {
   hero = new HeroState();
 
   this.worldLayer = this.add.container(0, 0);
+  mazeManager = new MazeManager(this);
+  const firstChunk = mazeManager.spawnInitial();
   heroSprite = this.add.rectangle(0, 0, 16, 16, 0x00ff00);
+  heroSprite.x = firstChunk.entrance.x * 16 + 8;
+  heroSprite.y = firstChunk.entrance.y * 16 + 8;
   this.worldLayer.add(heroSprite);
 
   uiLayer = this.add.container(0, 0);
   uiLayer.setScrollFactor(0);
 
-  this.cameras.main.setBounds(-500, -500, 1000, 1000);
+  this.cameras.main.setBounds(-1000, -1000, 10000, 10000);
   cameraController = new CameraController(this);
   cameraController.follow(heroSprite);
 
   cursors = this.input.keyboard.createCursorKeys();
+  wasdKeys = this.input.keyboard.addKeys('W,A,S,D');
 
   this.mazeText = this.add.text(10, 10, `Mazes Cleared: ${gameState.clearedMazes}`, {
     fontSize: '16px',
@@ -72,16 +80,37 @@ function create() {
 
 function update() {
   const speed = hero.speed;
-  if (cursors.left.isDown) {
-    heroSprite.x -= speed * this.game.loop.delta / 1000;
-  } else if (cursors.right.isDown) {
-    heroSprite.x += speed * this.game.loop.delta / 1000;
+  const delta = this.game.loop.delta;
+  let dx = 0;
+  let dy = 0;
+  if (cursors.left.isDown || wasdKeys.A.isDown) {
+    dx -= 1;
+  } else if (cursors.right.isDown || wasdKeys.D.isDown) {
+    dx += 1;
   }
 
-  if (cursors.up.isDown) {
-    heroSprite.y -= speed * this.game.loop.delta / 1000;
-  } else if (cursors.down.isDown) {
-    heroSprite.y += speed * this.game.loop.delta / 1000;
+  if (cursors.up.isDown || wasdKeys.W.isDown) {
+    dy -= 1;
+  } else if (cursors.down.isDown || wasdKeys.S.isDown) {
+    dy += 1;
+  }
+
+  const nextX = heroSprite.x + dx * speed * delta / 1000;
+  const nextY = heroSprite.y + dy * speed * delta / 1000;
+
+  const tileInfo = mazeManager.worldToTile(nextX, nextY);
+  if (!tileInfo || tileInfo.cell.type !== 'wall') {
+    heroSprite.x = nextX;
+    heroSprite.y = nextY;
+  }
+
+  mazeManager.update(delta, heroSprite);
+  const curTile = mazeManager.worldToTile(heroSprite.x, heroSprite.y);
+  if (curTile && curTile.cell.type === 'exit' && !curTile.chunk.chunk.exited) {
+    curTile.chunk.chunk.exited = true;
+    gameState.incrementMazeCount();
+    this.mazeText.setText(`Mazes Cleared: ${gameState.clearedMazes}`);
+    mazeManager.spawnNext(gameState.clearedMazes, curTile.chunk, heroSprite);
   }
 
   hero.moveTo(heroSprite.x, heroSprite.y);

--- a/maze.js
+++ b/maze.js
@@ -7,12 +7,12 @@ export class MazeChunk {
   constructor(width, height) {
     this.width = width;
     this.height = height;
-    this.tiles = this._generateMaze(width, height);
     this.age = 0;
     this.fading = false;
     this.entrance = null;
     this.exit = null;
     this.chest = null;
+    this.tiles = this._generateMaze(width, height);
   }
 
   _generateMaze(width, height) {

--- a/maze_manager.js
+++ b/maze_manager.js
@@ -1,0 +1,128 @@
+import { generateChunk } from './maze.js';
+
+export default class MazeManager {
+  constructor(scene) {
+    this.scene = scene;
+    this.tileSize = 16;
+    this.activeChunks = [];
+    this.chunkSpacing = 16;
+    this.fadeDelay = 8000; // ms until fade starts
+    this.fadeDuration = 2000; // fade time
+  }
+
+  spawnInitial() {
+    const chunk = generateChunk(0);
+    this.addChunk(chunk, 0, 0);
+    return chunk;
+  }
+
+  addChunk(chunk, offsetX, offsetY) {
+    const container = this.scene.add.container(offsetX, offsetY);
+    if (this.scene.worldLayer) {
+      this.scene.worldLayer.add(container);
+    }
+    container.alpha = 0;
+    this.scene.tweens.add({ targets: container, alpha: 1, duration: 400 });
+
+    this.renderChunk(chunk, container);
+    this.activeChunks.push({ chunk, container, offsetX, offsetY, age: 0, fading: false });
+  }
+
+  renderChunk(chunk, container) {
+    const size = this.tileSize;
+    for (let y = 0; y < chunk.height; y++) {
+      for (let x = 0; x < chunk.width; x++) {
+        const cell = chunk.tiles[y][x];
+        let color;
+        switch (cell.type) {
+          case 'wall':
+            color = 0x222222;
+            break;
+          case 'entrance':
+            color = 0x0000ff;
+            break;
+          case 'exit':
+            color = 0xff0000;
+            break;
+          case 'chest':
+            color = 0xffff00;
+            break;
+          case 'itemChest':
+            color = 0xff00ff;
+            break;
+          default:
+            color = 0x666666;
+        }
+        if (cell.type !== 'floor') {
+          const rect = this.scene.add.rectangle(
+            x * size + size / 2,
+            y * size + size / 2,
+            size,
+            size,
+            color
+          );
+          rect.setOrigin(0.5);
+          rect.setData('type', cell.type);
+          container.add(rect);
+        }
+      }
+    }
+  }
+
+  worldToTile(x, y) {
+    const size = this.tileSize;
+    for (const obj of this.activeChunks) {
+      const { chunk, offsetX, offsetY } = obj;
+      if (x >= offsetX && y >= offsetY && x < offsetX + chunk.width * size && y < offsetY + chunk.height * size) {
+        const tx = Math.floor((x - offsetX) / size);
+        const ty = Math.floor((y - offsetY) / size);
+        return { chunk: obj, cell: chunk.tiles[ty][tx], tx, ty };
+      }
+    }
+    return null;
+  }
+
+  update(delta, hero) {
+    for (const obj of this.activeChunks) {
+      obj.age += delta;
+      if (obj.age > this.fadeDelay && !obj.fading) {
+        obj.fading = true;
+        this.scene.tweens.add({
+          targets: obj.container,
+          alpha: 0,
+          duration: this.fadeDuration,
+          onComplete: () => {
+            if (this.isHeroInside(hero, obj)) {
+              this.scene.scene.restart();
+            }
+            obj.container.destroy();
+            this.activeChunks = this.activeChunks.filter(c => c !== obj);
+          }
+        });
+      }
+    }
+  }
+
+  isHeroInside(heroSprite, obj) {
+    const size = this.tileSize;
+    const { offsetX, offsetY, chunk } = obj;
+    return (
+      heroSprite.x >= offsetX &&
+      heroSprite.y >= offsetY &&
+      heroSprite.x < offsetX + chunk.width * size &&
+      heroSprite.y < offsetY + chunk.height * size
+    );
+  }
+
+  spawnNext(progress, fromObj, heroSprite) {
+    const last = this.activeChunks[this.activeChunks.length - 1];
+    const offsetX = last.offsetX + last.chunk.width * this.tileSize + this.chunkSpacing;
+    const offsetY = last.offsetY;
+    const chunk = generateChunk(progress);
+    this.addChunk(chunk, offsetX, offsetY);
+
+    heroSprite.x = offsetX + chunk.entrance.x * this.tileSize + this.tileSize / 2;
+    heroSprite.y = offsetY + chunk.entrance.y * this.tileSize + this.tileSize / 2;
+    this.scene.cameras.main.pan(heroSprite.x, heroSprite.y, 400);
+  }
+}


### PR DESCRIPTION
## Summary
- add MazeManager module for generating and fading maze chunks
- integrate MazeManager into Phaser game loop
- spawn first maze and move hero to maze entrance
- support WASD controls and restrict hero movement with maze walls
- spawn new maze chunks when reaching the exit

## Testing
- `node -e "import('./maze_manager.js').then(()=>console.log('ok')).catch(e=>console.error(e))"`

------
https://chatgpt.com/codex/tasks/task_e_6880b071aa8883339c25edbc9a7c1a73