### PR TITLE
Refine SVG assets

### DIFF
--- a/assets/arrow.svg
+++ b/assets/arrow.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <path d="M4 16h16" stroke="#ffffff" stroke-width="4" stroke-linecap="round"/>
+  <path d="M16 8l8 8-8 8" fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/exit.svg
+++ b/assets/exit.svg
@@ -1,4 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
-  <path d="M6 30V10a10 10 0 0120 0v20z" fill="#00aaff" stroke="#66ccff" stroke-width="2"/>
-  <circle cx="20" cy="18" r="2" fill="#ffffff"/>
+  <defs>
+    <linearGradient id="doorGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ff6666"/>
+      <stop offset="100%" stop-color="#aa0000"/>
+    </linearGradient>
+  </defs>
+  <path d="M6 30V10a10 10 0 0120 0v20z" fill="url(#doorGradient)" stroke="#ff9999" stroke-width="2"/>
+  <line x1="16" y1="12" x2="16" y2="28" stroke="#660000" stroke-width="1"/>
+  <circle cx="22" cy="20" r="2" fill="#ffeeee" stroke="#660000" stroke-width="1"/>
 </svg>

--- a/assets/floor.svg
+++ b/assets/floor.svg
@@ -1,4 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
-  <rect width="32" height="32" fill="#3d3d3d"/>
-  <path d="M0 8H32M0 16H32M0 24H32M8 0V32M16 0V32M24 0V32" stroke="#2a2a2a" stroke-width="1"/>
+  <defs>
+    <linearGradient id="floorGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a66b39"/>
+      <stop offset="100%" stop-color="#6b3f1a"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" fill="url(#floorGrad)"/>
+  <path d="M0 8H32M0 16H32M0 24H32" stroke="#5b3214" stroke-width="1"/>
+  <path d="M8 0V32M16 0V32M24 0V32" stroke="#5b3214" stroke-width="1"/>
+  <path d="M4 0V32M12 0V32M20 0V32M28 0V32" stroke="#7d4c26" stroke-width="0.5"/>
 </svg>

--- a/assets/hero.svg
+++ b/assets/hero.svg
@@ -1,10 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
-  <ellipse cx="16" cy="18" rx="12" ry="10" fill="#9acd32" stroke="#6aa84f" stroke-width="2"/>
-  <ellipse cx="8" cy="20" rx="4" ry="2" fill="#9acd32"/>
-  <ellipse cx="24" cy="20" rx="4" ry="2" fill="#9acd32"/>
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#aee868"/>
+      <stop offset="100%" stop-color="#6aa84f"/>
+    </linearGradient>
+  </defs>
+  <ellipse cx="16" cy="18" rx="12" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <ellipse cx="8" cy="20" rx="4" ry="2" fill="#8cc84b"/>
+  <ellipse cx="24" cy="20" rx="4" ry="2" fill="#8cc84b"/>
   <circle cx="10" cy="12" r="4" fill="#ffffff"/>
   <circle cx="22" cy="12" r="4" fill="#ffffff"/>
   <circle cx="10" cy="12" r="2" fill="#000000"/>
   <circle cx="22" cy="12" r="2" fill="#000000"/>
   <path d="M12 18 Q16 22 20 18" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M8 16 C10 14, 22 14, 24 16" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
 </svg>

--- a/assets/treasure.svg
+++ b/assets/treasure.svg
@@ -1,6 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
-  <rect x="4" y="14" width="24" height="14" fill="#d4a017" stroke="#996600" stroke-width="2"/>
-  <rect x="4" y="8" width="24" height="10" fill="#f4c430" stroke="#996600" stroke-width="2"/>
+  <defs>
+    <linearGradient id="chestLid" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffe08a"/>
+      <stop offset="100%" stop-color="#d4a017"/>
+    </linearGradient>
+    <linearGradient id="chestBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d4a017"/>
+      <stop offset="100%" stop-color="#b07c12"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="14" width="24" height="14" fill="url(#chestBody)" stroke="#996600" stroke-width="2"/>
+  <rect x="4" y="8" width="24" height="10" fill="url(#chestLid)" stroke="#996600" stroke-width="2"/>
   <line x1="4" y1="16" x2="28" y2="16" stroke="#996600" stroke-width="2"/>
+  <line x1="16" y1="14" x2="16" y2="28" stroke="#b07c12" stroke-width="1"/>
   <circle cx="16" cy="22" r="2" fill="#996600"/>
 </svg>

--- a/assets/wall.svg
+++ b/assets/wall.svg
@@ -1,5 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
-  <rect width="32" height="32" fill="#555555"/>
-  <path d="M0 8H32M0 16H32M0 24H32M8 0V16M16 0V16M24 0V16M4 16V32M12 16V32M20 16V32M28 16V32" stroke="#777777" stroke-width="2"/>
-  <rect width="32" height="32" fill="none" stroke="#777777" stroke-width="2"/>
+  <defs>
+    <linearGradient id="brickGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#777777"/>
+      <stop offset="100%" stop-color="#444444"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" fill="url(#brickGrad)"/>
+  <path d="M0 8H32M0 16H32M0 24H32" stroke="#555555" stroke-width="2"/>
+  <path d="M8 0V16M16 0V16M24 0V16M4 16V32M12 16V32M20 16V32M28 16V32" stroke="#555555" stroke-width="2"/>
+  <rect width="32" height="32" fill="none" stroke="#888888" stroke-width="2"/>
 </svg>

--- a/characters.js
+++ b/characters.js
@@ -5,7 +5,8 @@ const SPRITES = {
   wall: 'wall.svg',
   exit: 'exit.svg',
   treasure: 'treasure.svg',
-  hero: 'hero.svg'
+  hero: 'hero.svg',
+  arrow: 'arrow.svg'
 };
 
 const canvases = {};
@@ -60,6 +61,10 @@ function createHero(scene) {
   return scene.add.image(0, 0, 'hero').setOrigin(0.5);
 }
 
+function createArrow(scene) {
+  return scene.add.image(0, 0, 'arrow').setOrigin(0.5);
+}
+
 export default {
   ready,
   registerTextures,
@@ -67,5 +72,6 @@ export default {
   createWall,
   createExit,
   createTreasure,
-  createHero
+  createHero,
+  createArrow
 };


### PR DESCRIPTION
## Summary
- enhance all SVG graphics with gradients and detailing
- color the door red and the floor brown
- add a new arrow asset
- register the arrow sprite

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6880d6ecd43883339f0e30aac632be05