### PR TITLE
Refactor maze generation

### DIFF
--- a/game.js
+++ b/game.js
@@ -2,6 +2,7 @@ import GameState from './game-state.js';
 import HeroState from './hero_state.js';
 import CameraController from './camera.js';
 import MazeManager from './maze_manager.js';
+import { TILE_TYPES } from './maze.js';
 import Characters from './characters.js';
 
 // Global state for tracking overall game progress
@@ -103,7 +104,7 @@ function update() {
       const targetX = heroSprite.x + dx * size;
       const targetY = heroSprite.y + dy * size;
       const tileInfo = mazeManager.worldToTile(targetX, targetY);
-      if (!tileInfo || tileInfo.cell.type !== 'wall') {
+      if (!tileInfo || tileInfo.cell !== TILE_TYPES.WALL) {
         isMoving = true;
         this.tweens.add({
           targets: heroSprite,
@@ -120,7 +121,7 @@ function update() {
 
   mazeManager.update(delta, heroSprite);
   const curTile = mazeManager.worldToTile(heroSprite.x, heroSprite.y);
-  if (curTile && curTile.cell.type === 'exit' && !curTile.chunk.chunk.exited) {
+  if (curTile && curTile.cell === TILE_TYPES.DOOR && !curTile.chunk.chunk.exited) {
     curTile.chunk.chunk.exited = true;
     gameState.incrementMazeCount();
     this.mazeText.setText(`Mazes Cleared: ${gameState.clearedMazes}`);

--- a/maze_manager.js
+++ b/maze_manager.js
@@ -1,4 +1,4 @@
-import { generateChunk } from './maze.js';
+import { generateChunk, TILE_TYPES } from './maze.js';
 import Characters from './characters.js';
 
 export default class MazeManager {
@@ -7,17 +7,22 @@ export default class MazeManager {
     this.tileSize = 16;
     this.activeChunks = [];
     this.chunkSpacing = 16;
-    this.fadeDelay = 8000; // ms until fade starts
-    this.fadeDuration = 2000; // fade time
+    this.baseTTL = 12000;
+    this.minTTL = 6000;
   }
 
   spawnInitial() {
     const chunk = generateChunk(0);
-    this.addChunk(chunk, 0, 0);
+    this.addChunk(chunk, 0, 0, 0);
     return chunk;
   }
 
-  addChunk(chunk, offsetX, offsetY) {
+  _calcTTL(progress) {
+    const dec = Math.floor(progress / 5) * 1000;
+    return Math.max(this.baseTTL - dec, this.minTTL);
+  }
+
+  addChunk(chunk, offsetX, offsetY, progress = 0) {
     const container = this.scene.add.container(offsetX, offsetY);
     if (this.scene.worldLayer) {
       this.scene.worldLayer.add(container);
@@ -26,39 +31,51 @@ export default class MazeManager {
     this.scene.tweens.add({ targets: container, alpha: 1, duration: 400 });
 
     this.renderChunk(chunk, container);
-    this.activeChunks.push({ chunk, container, offsetX, offsetY, age: 0, fading: false });
+    const ttl = this._calcTTL(progress);
+    const bloom = ttl * 0.1;
+    const fadeOut = ttl - bloom;
+    this.activeChunks.push({
+      chunk,
+      container,
+      offsetX,
+      offsetY,
+      age: 0,
+      bloom,
+      fadeOut,
+      ttl,
+      bloomStarted: false,
+      fading: false
+    });
   }
 
   renderChunk(chunk, container) {
     const size = this.tileSize;
     for (let y = 0; y < chunk.height; y++) {
       for (let x = 0; x < chunk.width; x++) {
-        const cell = chunk.tiles[y][x];
-        // always draw base floor
+        const idx = y * chunk.width + x;
+        const cell = chunk.tiles[idx];
         const floor = Characters.createFloor(this.scene);
         floor.setDisplaySize(size, size);
         floor.setPosition(x * size, y * size);
         container.add(floor);
 
         let sprite = null;
-        switch (cell.type) {
-          case 'wall':
+        switch (cell) {
+          case TILE_TYPES.WALL:
             sprite = Characters.createWall(this.scene);
             break;
-          case 'exit':
+          case TILE_TYPES.DOOR:
             sprite = Characters.createExit(this.scene);
             break;
-          case 'chest':
-          case 'itemChest':
+          case TILE_TYPES.KEY_CHEST:
+          case TILE_TYPES.ITEM_CHEST:
             sprite = Characters.createTreasure(this.scene);
             break;
-          // entrance and floor just use floor graphic
         }
 
         if (sprite) {
           sprite.setDisplaySize(size, size);
           sprite.setPosition(x * size, y * size);
-          sprite.setData('type', cell.type);
           container.add(sprite);
         }
       }
@@ -72,7 +89,8 @@ export default class MazeManager {
       if (x >= offsetX && y >= offsetY && x < offsetX + chunk.width * size && y < offsetY + chunk.height * size) {
         const tx = Math.floor((x - offsetX) / size);
         const ty = Math.floor((y - offsetY) / size);
-        return { chunk: obj, cell: chunk.tiles[ty][tx], tx, ty };
+        const idx = ty * chunk.width + tx;
+        return { chunk: obj, cell: chunk.tiles[idx], tx, ty };
       }
     }
     return null;
@@ -81,12 +99,18 @@ export default class MazeManager {
   update(delta, hero) {
     for (const obj of this.activeChunks) {
       obj.age += delta;
-      if (obj.age > this.fadeDelay && !obj.fading) {
+      if (!obj.bloomStarted && obj.age >= obj.ttl - obj.fadeOut - obj.bloom) {
+        obj.bloomStarted = true;
+        // quick flash effect before fade out
+        this.scene.tweens.add({ targets: obj.container, alpha: 1, duration: obj.bloom });
+      }
+
+      if (!obj.fading && obj.age >= obj.ttl - obj.fadeOut) {
         obj.fading = true;
         this.scene.tweens.add({
           targets: obj.container,
           alpha: 0,
-          duration: this.fadeDuration,
+          duration: obj.fadeOut,
           onComplete: () => {
             if (this.isHeroInside(hero, obj)) {
               this.scene.scene.restart();
@@ -115,7 +139,7 @@ export default class MazeManager {
     const offsetX = last.offsetX + last.chunk.width * this.tileSize + this.chunkSpacing;
     const offsetY = last.offsetY;
     const chunk = generateChunk(progress);
-    this.addChunk(chunk, offsetX, offsetY);
+    this.addChunk(chunk, offsetX, offsetY, progress);
 
     heroSprite.x = offsetX + chunk.entrance.x * this.tileSize + this.tileSize / 2;
     heroSprite.y = offsetY + chunk.entrance.y * this.tileSize + this.tileSize / 2;


### PR DESCRIPTION
## Summary
- implement typed tile constants and seed-aware MazeChunk
- generate mazes with DFS on a typed array
- add TTL-based fading based on difficulty
- adapt game logic to new tile values

## Testing
- `node --check maze.js`
- `node --check maze_manager.js`
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_6880db7cb1648333a52a1c6d337a5466