### PR TITLE
Fix double walls on maze edges

### DIFF
--- a/maze_generator_core.js
+++ b/maze_generator_core.js
@@ -68,8 +68,12 @@ export class MazeChunk {
     tiles.fill(TILE.WALL);
 
     const stack = [];
-    const startX = rng.nextInt(size - 2) + 1;
-    const startY = rng.nextInt(size - 2) + 1;
+    // ensure starting position is on an odd tile so that the
+    // maze paths reach the very first interior row/column
+    // (avoids double-thick walls on the north and west edges)
+    const maxIdx = Math.floor((size - 1) / 2);
+    const startX = rng.nextInt(maxIdx) * 2 + 1;
+    const startY = rng.nextInt(maxIdx) * 2 + 1;
     stack.push({ x: startX, y: startY });
     tiles[index(startX, startY, size)] = TILE.FLOOR;
 


### PR DESCRIPTION
## Summary
- adjust maze generation to always start on odd tiles
  - prevents double-thick north/west outer walls

## Testing
- `node -e "const {createChunk, TILE} = require('./maze_generator_core.js'); const chunk=createChunk('seed'); let row0=''; let row1=''; for(let x=0;x<chunk.size;x++){row0+=chunk.tiles[x]==TILE.WALL?'#':'.';row1+=chunk.tiles[chunk.size+x]==TILE.WALL?'#':'.';} console.log(chunk.size);console.log('row0:'+row0);console.log('row1:'+row1);"`

------
https://chatgpt.com/codex/tasks/task_e_6880ecd7ecf08333acb26f059dcd0ee5