### PR TITLE
Reduce hero speed

### DIFF
--- a/hero_state.js
+++ b/hero_state.js
@@ -2,8 +2,8 @@ export default class HeroState {
   constructor() {
     this.health = 3; // プレイヤーの残りHP
     // Base movement speed in pixels per second
-    // Increased by five times from the original value
-    this.speed = 1000;
+    // Reduced to half of the previously boosted value
+    this.speed = 500;
     this.position = { x: 0, y: 0 };
     this.inventory = [];
     this.powerUps = [];


### PR DESCRIPTION
## Summary
- reduce the hero's movement speed to half of the boosted value

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880f1e7db2c83339d80445702e869e4