### PR TITLE
Fix maze generation edges and chunk spacing

### DIFF
--- a/maze_generator_core.js
+++ b/maze_generator_core.js
@@ -76,7 +76,29 @@ export class MazeChunk {
     const startY = rng.nextInt(maxIdx) * 2 + 1;
     stack.push({ x: startX, y: startY });
     tiles[index(startX, startY, size)] = TILE.FLOOR;
+    this._dfs(stack, tiles, rng);
 
+    // second pass starting on even coordinates to reach the
+    // rows/columns skipped by the first pass (avoids double
+    // outer walls on the south/east sides when size is even)
+    const startX2 = rng.nextInt(maxIdx) * 2 + 2;
+    const startY2 = rng.nextInt(maxIdx) * 2 + 2;
+    if (
+      startX2 < size - 1 &&
+      startY2 < size - 1 &&
+      tiles[index(startX2, startY2, size)] === TILE.WALL
+    ) {
+      stack.push({ x: startX2, y: startY2 });
+      tiles[index(startX2, startY2, size)] = TILE.FLOOR;
+      this._dfs(stack, tiles, rng);
+    }
+
+    this._placeSpecials(rng);
+    this._addDetours(rng);
+  }
+
+  _dfs(stack, tiles, rng) {
+    const size = this.size;
     while (stack.length) {
       const { x, y } = stack[stack.length - 1];
       const neighbors = [];
@@ -99,9 +121,6 @@ export class MazeChunk {
         stack.pop();
       }
     }
-
-    this._placeSpecials(rng);
-    this._addDetours(rng);
   }
 
   _randomFloor(rng) {

--- a/maze_manager.js
+++ b/maze_manager.js
@@ -6,7 +6,8 @@ export default class MazeManager {
     this.scene = scene;
     this.tileSize = 16;
     this.activeChunks = [];
-    this.chunkSpacing = 16;
+    // spacing between chunks; 0 keeps them connected
+    this.chunkSpacing = 0;
     this.fadeDelay = 8000; // ms until fade starts
     this.fadeDuration = 2000; // fade time
     this.events = new Phaser.Events.EventEmitter();


### PR DESCRIPTION
## Summary
- prevent double-thick south wall by visiting even coordinate tiles
- expose `_dfs` helper for maze generation
- place new chunks directly adjacent to the previous one

## Testing
- `node - <<'EOF'
const {MazeChunk}=require('./maze_generator_core.js');
const c=new MazeChunk('test',12,'W');
for(let y=0;y<c.size;y++){console.log(Array.from(c.tiles.slice(y*c.size,(y+1)*c.size)).join(' '));}
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6880f1d6699c8333b8e66aabb5a68c35