### PR TITLE
Fix double southern wall in maze generation

### DIFF
--- a/maze_generator_core.js
+++ b/maze_generator_core.js
@@ -100,6 +100,7 @@ export class MazeChunk {
       }
     }
 
+    this._fixEvenSizeWalls();
     this._placeSpecials(rng);
     this._addDetours(rng);
   }
@@ -155,6 +156,22 @@ export class MazeChunk {
       if (tiles[idx] === TILE.WALL) {
         tiles[idx] = TILE.FLOOR;
       }
+    }
+  }
+
+  _fixEvenSizeWalls() {
+    const size = this.size;
+    if (size % 2 !== 0) return;
+    const tiles = this.tiles;
+    const bottomY = size - 2;
+    const aboveY = size - 3;
+    for (let x = 1; x < size - 1; x++) {
+      tiles[index(x, bottomY, size)] = tiles[index(x, aboveY, size)];
+    }
+    const rightX = size - 2;
+    const leftOfRightX = size - 3;
+    for (let y = 1; y < size - 1; y++) {
+      tiles[index(rightX, y, size)] = tiles[index(leftOfRightX, y, size)];
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure even-sized mazes replicate the second-to-last row/column into the last interior row/column
- invoke `_fixEvenSizeWalls` before placing chest and door

## Testing
- `node -e "const {createChunk}=require('./maze_generator_core.js'); const c=createChunk('seed',12,'W'); const s=c.size; for(let y=0;y<s;y++){ let row=''; for(let x=0;x<s;x++){ row+=c.tiles[y*s+x]; } console.log(y,row); }"`


------
https://chatgpt.com/codex/tasks/task_e_6880f511e6008333bb7d1d8fd56275bc