### PR TITLE
Follow directional placement rules for maze chunks

### DIFF
--- a/maze_manager.js
+++ b/maze_manager.js
@@ -134,16 +134,53 @@ export default class MazeManager {
   }
 
   spawnNext(progress, fromObj, heroSprite) {
-    const last = this.activeChunks[this.activeChunks.length - 1];
-    const offsetX = last.offsetX + last.chunk.size * this.tileSize + this.chunkSpacing;
-    const offsetY = last.offsetY;
-    const chunk = createChunk(`chunk${progress}`, 13, 'W');
+    const doorDir = fromObj.chunk.door ? fromObj.chunk.door.dir : 'E';
+    const entryDir = this._oppositeDir(doorDir);
+    const chunk = createChunk(`chunk${progress}`, 13, entryDir);
     this._ensureEntrance(chunk);
+
+    const { offsetX, offsetY } = this._calcOffset(fromObj, chunk.size, doorDir);
     const info = this.addChunk(chunk, offsetX, offsetY);
 
     heroSprite.x = offsetX + chunk.entrance.x * this.tileSize + this.tileSize / 2;
     heroSprite.y = offsetY + chunk.entrance.y * this.tileSize + this.tileSize / 2;
     return info;
+  }
+
+  _oppositeDir(dir) {
+    switch (dir) {
+      case 'N':
+        return 'S';
+      case 'S':
+        return 'N';
+      case 'W':
+        return 'E';
+      case 'E':
+      default:
+        return 'W';
+    }
+  }
+
+  _calcOffset(fromObj, newSize, dir) {
+    const size = this.tileSize;
+    let offsetX = fromObj.offsetX;
+    let offsetY = fromObj.offsetY;
+    switch (dir) {
+      case 'N':
+        offsetY = fromObj.offsetY - (newSize - 1) * size;
+        break;
+      case 'S':
+        offsetY = fromObj.offsetY + (fromObj.chunk.size - 1) * size;
+        break;
+      case 'W':
+        offsetX = fromObj.offsetX - (newSize - 1) * size;
+        break;
+      case 'E':
+      default:
+        offsetX = fromObj.offsetX + (fromObj.chunk.size - 1) * size;
+        break;
+    }
+    return { offsetX, offsetY };
   }
 
   _ensureEntrance(chunk) {


### PR DESCRIPTION
## Summary
- follow docs/genrate_new_mage rules for placing new maze chunks
- compute offset from previous chunk's exit door direction
- spawn new chunks with the correct entry direction

## Testing
- `node --check maze_manager.js`

------
https://chatgpt.com/codex/tasks/task_e_688101fb6b1c8333ba73a83498988bda