### PR TITLE
Fix hero overlaying issue in new chunks

### DIFF
--- a/maze_manager.js
+++ b/maze_manager.js
@@ -22,7 +22,8 @@ export default class MazeManager {
   addChunk(chunk, offsetX, offsetY) {
     const container = this.scene.add.container(offsetX, offsetY);
     if (this.scene.worldLayer) {
-      this.scene.worldLayer.add(container);
+      // Add new chunk containers behind the hero so the character remains visible
+      this.scene.worldLayer.addAt(container, 0);
     }
     container.alpha = 0;
     this.scene.tweens.add({ targets: container, alpha: 1, duration: 400 });


### PR DESCRIPTION
## Summary
- ensure newly added maze chunks render behind the hero

The hero was disappearing whenever a new maze chunk was spawned. This was due to new chunk containers being added on top of the hero's sprite in the `worldLayer` container. By inserting new chunks at index 0, the hero remains above them.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688106f7e3d483338fddd1f1103d3a84