### PR TITLE
Add silver door asset

### DIFF
--- a/assets/door_silver.svg
+++ b/assets/door_silver.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <defs>
+    <linearGradient id="doorSilverGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#cccccc"/>
+      <stop offset="100%" stop-color="#888888"/>
+    </linearGradient>
+  </defs>
+  <path d="M6 30V10a10 10 0 0120 0v20z" fill="url(#doorSilverGradient)" stroke="#bbbbbb" stroke-width="2"/>
+  <line x1="16" y1="12" x2="16" y2="28" stroke="#555555" stroke-width="1"/>
+  <circle cx="22" cy="20" r="2" fill="#eeeeee" stroke="#555555" stroke-width="1"/>
+</svg>


### PR DESCRIPTION
## Summary
- add a silver door SVG asset based on the red door design

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68810af8a0d08333b4e3b7ca85547b3b