### PR TITLE
Fix camera drift with center correction

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -23,10 +23,7 @@ export default class CameraManager {
    * @param {number} duration - tween 時間 (ms)
    */
   panToChunk(info, duration = 400) {
-    const size = this.mazeManager.tileSize;
-    const chunkSize = info.chunk.size || info.chunk.width || 0;
-    const cx = info.offsetX + (chunkSize * size) / 2;
-    const cy = info.offsetY + (chunkSize * size) / 2;
+    const { x: cx, y: cy } = this.mazeManager.getChunkCenter(info);
     this.expectedCenter.x = cx;
     this.expectedCenter.y = cy;
     this.cam.pan(cx, cy, duration, 'Sine.easeInOut');

--- a/camera.js
+++ b/camera.js
@@ -3,6 +3,13 @@ export default class CameraManager {
     this.scene = scene;
     this.mazeManager = mazeManager;
     this.cam = scene.cameras.main;
+    this.bounds = { minX: -1000, minY: -1000, maxX: 9000, maxY: 9000 };
+    this.cam.setBounds(
+      this.bounds.minX,
+      this.bounds.minY,
+      this.bounds.maxX - this.bounds.minX,
+      this.bounds.maxY - this.bounds.minY
+    );
     // Keep track of where the camera should be centered
     this.expectedCenter = {
       x: this.cam.midPoint.x,
@@ -62,6 +69,21 @@ export default class CameraManager {
         this.cam.centerOn(x, y);
       }
     }
+  }
+
+  /**
+   * Update camera bounds so all chunks remain within view.
+   * Call whenever a new chunk is added.
+   * @param {object} info - chunk info from MazeManager
+   */
+  expandBounds(info) {
+    const size = this.mazeManager.tileSize * info.chunk.size;
+    const minX = Math.min(this.bounds.minX, info.offsetX);
+    const minY = Math.min(this.bounds.minY, info.offsetY);
+    const maxX = Math.max(this.bounds.maxX, info.offsetX + size);
+    const maxY = Math.max(this.bounds.maxY, info.offsetY + size);
+    this.bounds = { minX, minY, maxX, maxY };
+    this.cam.setBounds(minX, minY, maxX - minX, maxY - minY);
   }
 
   setZoom(zoom, duration = 0) {

--- a/game.js
+++ b/game.js
@@ -53,11 +53,10 @@ class GameScene extends Phaser.Scene {
     this.cameraManager = new CameraManager(this, this.mazeManager);
     this.cameraManager.expandBounds(firstInfo);
     this.cameraManager.panToChunk(firstInfo, 0);
+    // Update bounds whenever a chunk is added
     this.mazeManager.events.on('chunk-added', info => {
       if (info !== firstInfo) {
         this.cameraManager.expandBounds(info);
-        this.cameraManager.panToChunk(info);
-        this.cameraManager.zoomBump();
       }
     });
 
@@ -164,7 +163,13 @@ class GameScene extends Phaser.Scene {
           gameState.addScore(100);
           this.events.emit('updateScore', gameState.score);
           this.events.emit('updateKeys', this.hero.keys);
-          this.mazeManager.spawnNext(gameState.clearedMazes, curTile.chunk, this.heroSprite);
+          const nextInfo = this.mazeManager.spawnNext(
+            gameState.clearedMazes,
+            curTile.chunk,
+            this.heroSprite
+          );
+          this.cameraManager.panToChunk(nextInfo);
+          this.cameraManager.zoomBump();
         } else {
           if (curTile.chunk.doorSprite) {
             this.tweens.add({

--- a/game.js
+++ b/game.js
@@ -50,11 +50,12 @@ class GameScene extends Phaser.Scene {
     this.worldLayer.add(this.keyDisplay);
     this.updateKeyDisplay();
 
-    this.cameras.main.setBounds(-1000, -1000, 10000, 10000);
     this.cameraManager = new CameraManager(this, this.mazeManager);
+    this.cameraManager.expandBounds(firstInfo);
     this.cameraManager.panToChunk(firstInfo, 0);
     this.mazeManager.events.on('chunk-added', info => {
       if (info !== firstInfo) {
+        this.cameraManager.expandBounds(info);
         this.cameraManager.panToChunk(info);
         this.cameraManager.zoomBump();
       }

--- a/game.js
+++ b/game.js
@@ -182,6 +182,9 @@ class GameScene extends Phaser.Scene {
     this.keyDisplay.y = this.heroSprite.y - this.mazeManager.tileSize;
 
     this.hero.moveTo(this.heroSprite.x, this.heroSprite.y);
+
+    // Prevent camera drift by re-centering if needed
+    this.cameraManager.maintainCenter();
   }
 
   updateKeyDisplay() {

--- a/maze_manager.js
+++ b/maze_manager.js
@@ -17,6 +17,20 @@ export default class MazeManager {
     this.events = new Phaser.Events.EventEmitter();
   }
 
+  /**
+   * Get the world-center position of a chunk info object
+   * @param {object} info
+   * @returns {{x:number,y:number}}
+   */
+  getChunkCenter(info) {
+    const size = this.tileSize;
+    const c = info.chunk.size || info.chunk.width || 0;
+    return {
+      x: info.offsetX + (c * size) / 2,
+      y: info.offsetY + (c * size) / 2
+    };
+  }
+
   _nextSeed() {
     return `${this.seedBase}-${this.seedCount++}`;
   }


### PR DESCRIPTION
## Summary
- track expected camera center in `CameraManager`
- correct camera position each frame to avoid drift

## Testing
- `node --check camera.js`
- `node --check game.js`
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68811c0b7390833382dc50f48d8015d2