### PR TITLE
Add spawn transition effect

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -1,0 +1,57 @@
+export function newChunkTransition(scene, doorDir, doorWorldX, doorWorldY) {
+  const size = scene.mazeManager.tileSize;
+  const screenW = scene.cameras.main.width;
+  const screenH = scene.cameras.main.height;
+  const crossLength = Math.max(screenW, screenH) * 1.5;
+  const planeLength = Math.max(screenW, screenH) * 2;
+  const vertical = doorDir === 'E' || doorDir === 'W';
+  const thickness = size * 1.5;
+  const rect = scene.add.rectangle(
+    doorWorldX + size / 2,
+    doorWorldY + size / 2,
+    vertical ? thickness : crossLength,
+    vertical ? crossLength : thickness,
+    0xffffff
+  );
+  rect.setOrigin(0.5);
+  rect.setDepth(1000);
+  scene.worldLayer.add(rect);
+
+  if (vertical) {
+    rect.scaleY = 0;
+    scene.tweens.add({
+      targets: rect,
+      scaleY: 1,
+      duration: 100,
+      onComplete: () => {
+        rect.fillAlpha = 0.5;
+        scene.tweens.add({
+          targets: rect,
+          x: rect.x + (doorDir === 'E' ? planeLength : -planeLength),
+          displayWidth: crossLength,
+          duration: 300,
+          ease: 'Sine.easeIn',
+          onComplete: () => rect.destroy()
+        });
+      }
+    });
+  } else {
+    rect.scaleX = 0;
+    scene.tweens.add({
+      targets: rect,
+      scaleX: 1,
+      duration: 100,
+      onComplete: () => {
+        rect.fillAlpha = 0.5;
+        scene.tweens.add({
+          targets: rect,
+          y: rect.y + (doorDir === 'S' ? planeLength : -planeLength),
+          displayHeight: crossLength,
+          duration: 300,
+          ease: 'Sine.easeIn',
+          onComplete: () => rect.destroy()
+        });
+      }
+    });
+  }
+}

--- a/game.js
+++ b/game.js
@@ -6,6 +6,7 @@ import { TILE } from './maze_generator_core.js';
 import Characters from './characters.js';
 import InputBuffer from './input_buffer.js';
 import UIScene from './ui_scene.js';
+import { newChunkTransition } from './effects.js';
 
 const VIRTUAL_WIDTH = 480;
 const VIRTUAL_HEIGHT = 270;
@@ -58,6 +59,9 @@ class GameScene extends Phaser.Scene {
         this.cameraManager.panToChunk(info);
         this.cameraManager.zoomBump();
       }
+    });
+    this.mazeManager.events.on('spawn-next', data => {
+      newChunkTransition(this, data.doorDir, data.doorWorldX, data.doorWorldY);
     });
 
     this.cursors = this.input.keyboard.createCursorKeys();

--- a/maze_manager.js
+++ b/maze_manager.js
@@ -223,6 +223,14 @@ export default class MazeManager {
 
     heroSprite.x = offsetX + chunk.entrance.x * this.tileSize + this.tileSize / 2;
     heroSprite.y = offsetY + chunk.entrance.y * this.tileSize + this.tileSize / 2;
+
+    this.events.emit('spawn-next', {
+      doorDir,
+      doorWorldX,
+      doorWorldY,
+      info
+    });
+
     return info;
   }
 


### PR DESCRIPTION
## Summary
- emit `spawn-next` event when new chunk is spawned
- add `effects.js` with newChunkTransition helper
- hook GameScene to play the new transition effect

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6881227b4ee88333883679d75471a738