### PR TITLE
Add variable sizes and multi-door chance

### DIFF
--- a/game.js
+++ b/game.js
@@ -149,13 +149,16 @@ class GameScene extends Phaser.Scene {
         this.events.emit('updateKeys', this.hero.keys);
       }
 
-      if (
-        curTile.cell === TILE.SILVER_DOOR &&
-        !curTile.chunk.chunk.silverOpened &&
-        this.hero.keys > 0
-      ) {
-        curTile.chunk.chunk.silverOpened = true;
-        this.mazeManager.openSilverDoor(curTile.chunk);
+      if (curTile.cell === TILE.SILVER_DOOR && this.hero.keys > 0) {
+        const doors = curTile.chunk.chunk.silverDoors || [];
+        const door = doors.find(d => d.x === curTile.tx && d.y === curTile.ty);
+        if (door && !door.opened) {
+          this.mazeManager.openSilverDoor(
+            curTile.chunk,
+            curTile.tx,
+            curTile.ty
+          );
+        }
       }
 
       if (curTile.cell === TILE.DOOR && !curTile.chunk.chunk.exited) {

--- a/maze_manager.js
+++ b/maze_manager.js
@@ -75,8 +75,10 @@ export default class MazeManager {
             break;
           case TILE.SILVER_DOOR:
             sprite = Characters.createSilverDoor(this.scene);
-            info.silverDoorSprite = sprite;
-            info.silverDoorPosition = { x, y };
+            if (!info.silverDoorSprites) {
+              info.silverDoorSprites = [];
+            }
+            info.silverDoorSprites.push(sprite);
             break;
           case TILE.CHEST:
           case TILE.ITEM_CHEST:
@@ -316,11 +318,18 @@ export default class MazeManager {
         }
       }
     }
+    const doors = [];
     if (candidates.length) {
-      const spot = candidates[Math.floor(Math.random() * candidates.length)];
-      chunk.tiles[spot.y * size + spot.x] = TILE.SILVER_DOOR;
-      chunk.silverDoor = spot;
+      const doorCount =
+        size >= 11 && Math.random() < 0.5 ? 2 : 1;
+      for (let i = 0; i < doorCount && candidates.length; i++) {
+        const idx = Math.floor(Math.random() * candidates.length);
+        const spot = candidates.splice(idx, 1)[0];
+        chunk.tiles[spot.y * size + spot.x] = TILE.SILVER_DOOR;
+        doors.push(spot);
+      }
     }
+    chunk.silverDoors = doors;
   }
 
   openDoor(info) {
@@ -330,8 +339,10 @@ export default class MazeManager {
   }
 
   openSilverDoor(info) {
-    if (info && info.silverDoorSprite) {
-      info.silverDoorSprite.setTexture('door_silver_open');
+    if (info && info.silverDoorSprites) {
+      for (const sprite of info.silverDoorSprites) {
+        sprite.setTexture('door_silver_open');
+      }
     }
   }
 

--- a/maze_manager.js
+++ b/maze_manager.js
@@ -45,7 +45,8 @@ export default class MazeManager {
       age: 0,
       fading: false,
       doorSprite: null,
-      chestSprite: null
+      chestSprite: null,
+      silverDoors: []
     };
     this.renderChunk(chunk, container, info);
     this.activeChunks.push(info);
@@ -75,10 +76,13 @@ export default class MazeManager {
             break;
           case TILE.SILVER_DOOR:
             sprite = Characters.createSilverDoor(this.scene);
-            if (!info.silverDoorSprites) {
-              info.silverDoorSprites = [];
+            if (chunk.silverDoors) {
+              const d = chunk.silverDoors.find(v => v.x === x && v.y === y);
+              if (d) {
+                d.sprite = sprite;
+                info.silverDoors.push(d);
+              }
             }
-            info.silverDoorSprites.push(sprite);
             break;
           case TILE.CHEST:
           case TILE.ITEM_CHEST:
@@ -326,7 +330,7 @@ export default class MazeManager {
         const idx = Math.floor(Math.random() * candidates.length);
         const spot = candidates.splice(idx, 1)[0];
         chunk.tiles[spot.y * size + spot.x] = TILE.SILVER_DOOR;
-        doors.push(spot);
+        doors.push({ x: spot.x, y: spot.y, opened: false });
       }
     }
     chunk.silverDoors = doors;
@@ -338,10 +342,14 @@ export default class MazeManager {
     }
   }
 
-  openSilverDoor(info) {
-    if (info && info.silverDoorSprites) {
-      for (const sprite of info.silverDoorSprites) {
-        sprite.setTexture('door_silver_open');
+  openSilverDoor(info, x, y) {
+    if (info && info.silverDoors) {
+      const door = info.silverDoors.find(d => d.x === x && d.y === y);
+      if (door && !door.opened) {
+        if (door.sprite) {
+          door.sprite.setTexture('door_silver_open');
+        }
+        door.opened = true;
       }
     }
   }

--- a/maze_table.js
+++ b/maze_table.js
@@ -1,6 +1,7 @@
 export const MAZE_TABLE = [
   { stage: 1, sizes: [7] },
-  { stage: 2, sizes: [9, 11, 13] }
+  // From the second chunk onward allow a wider range including 7 again
+  { stage: 2, sizes: [7, 9, 11, 13] }
 ];
 
 export function pickMazeConfig(stage) {


### PR DESCRIPTION
## Summary
- allow second and later maze chunks to use sizes 7, 9, 11 and 13
- support spawning two silver doors on large mazes

## Testing
- `node --check maze_table.js`
- `node --check maze_manager.js`


------
https://chatgpt.com/codex/tasks/task_e_6881991578188333b90d6fe21388f17f