### PR TITLE
Neonify SVG assets using HSL

### DIFF
--- a/assets/arrow.svg
+++ b/assets/arrow.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
-  <path d="M4 16h16" stroke="#ffffff" stroke-width="4" stroke-linecap="round"/>
-  <path d="M16 8l8 8-8 8" fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M4 16h16" stroke="hsl(0,100%,50%)" stroke-width="4" stroke-linecap="round"/>
+  <path d="M16 8l8 8-8 8" fill="none" stroke="hsl(0,100%,50%)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/assets/door_closed.svg
+++ b/assets/door_closed.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="doorGradient" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#ff6666"/>
-      <stop offset="100%" stop-color="#aa0000"/>
+      <stop offset="0%" stop-color="hsl(0,100%,50%)"/>
+      <stop offset="100%" stop-color="hsl(0,100%,50%)"/>
     </linearGradient>
   </defs>
-  <path d="M6 30V10a10 10 0 0120 0v20z" fill="url(#doorGradient)" stroke="#ff9999" stroke-width="2"/>
-  <line x1="16" y1="12" x2="16" y2="28" stroke="#660000" stroke-width="1"/>
-  <circle cx="22" cy="20" r="2" fill="#ffeeee" stroke="#660000" stroke-width="1"/>
+  <path d="M6 30V10a10 10 0 0120 0v20z" fill="url(#doorGradient)" stroke="hsl(0,100%,50%)" stroke-width="2"/>
+  <line x1="16" y1="12" x2="16" y2="28" stroke="hsl(0,100%,50%)" stroke-width="1"/>
+  <circle cx="22" cy="20" r="2" fill="hsl(0,100%,50%)" stroke="hsl(0,100%,50%)" stroke-width="1"/>
 </svg>

--- a/assets/door_open.svg
+++ b/assets/door_open.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="doorOpenGradient" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#ff6666"/>
-      <stop offset="100%" stop-color="#aa0000"/>
+      <stop offset="0%" stop-color="hsl(0,100%,50%)"/>
+      <stop offset="100%" stop-color="hsl(0,100%,50%)"/>
     </linearGradient>
   </defs>
-  <polygon points="6,30 6,10 18,8 18,28" fill="url(#doorOpenGradient)" stroke="#ff9999" stroke-width="2"/>
-  <polygon points="18,8 26,10 26,30 18,28" fill="url(#doorOpenGradient)" stroke="#cc6666" stroke-width="2"/>
-  <circle cx="22" cy="20" r="2" fill="#ffeeee" stroke="#660000" stroke-width="1"/>
+  <polygon points="6,30 6,10 18,8 18,28" fill="url(#doorOpenGradient)" stroke="hsl(0,100%,50%)" stroke-width="2"/>
+  <polygon points="18,8 26,10 26,30 18,28" fill="url(#doorOpenGradient)" stroke="hsl(0,100%,50%)" stroke-width="2"/>
+  <circle cx="22" cy="20" r="2" fill="hsl(0,100%,50%)" stroke="hsl(0,100%,50%)" stroke-width="1"/>
 </svg>

--- a/assets/door_silver.svg
+++ b/assets/door_silver.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="doorSilverGradient" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#cccccc"/>
-      <stop offset="100%" stop-color="#888888"/>
+      <stop offset="0%" stop-color="hsl(0,100%,50%)"/>
+      <stop offset="100%" stop-color="hsl(0,100%,50%)"/>
     </linearGradient>
   </defs>
-  <path d="M6 30V10a10 10 0 0120 0v20z" fill="url(#doorSilverGradient)" stroke="#bbbbbb" stroke-width="2"/>
-  <line x1="16" y1="12" x2="16" y2="28" stroke="#555555" stroke-width="1"/>
-  <circle cx="22" cy="20" r="2" fill="#eeeeee" stroke="#555555" stroke-width="1"/>
+  <path d="M6 30V10a10 10 0 0120 0v20z" fill="url(#doorSilverGradient)" stroke="hsl(0,100%,50%)" stroke-width="2"/>
+  <line x1="16" y1="12" x2="16" y2="28" stroke="hsl(0,100%,50%)" stroke-width="1"/>
+  <circle cx="22" cy="20" r="2" fill="hsl(0,100%,50%)" stroke="hsl(0,100%,50%)" stroke-width="1"/>
 </svg>

--- a/assets/door_silver_open.svg
+++ b/assets/door_silver_open.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="doorSilverOpenGradient" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#cccccc"/>
-      <stop offset="100%" stop-color="#888888"/>
+      <stop offset="0%" stop-color="hsl(0,100%,50%)"/>
+      <stop offset="100%" stop-color="hsl(0,100%,50%)"/>
     </linearGradient>
   </defs>
-  <polygon points="6,30 6,10 18,8 18,28" fill="url(#doorSilverOpenGradient)" stroke="#bbbbbb" stroke-width="2"/>
-  <polygon points="18,8 26,10 26,30 18,28" fill="url(#doorSilverOpenGradient)" stroke="#888888" stroke-width="2"/>
-  <circle cx="22" cy="20" r="2" fill="#eeeeee" stroke="#555555" stroke-width="1"/>
+  <polygon points="6,30 6,10 18,8 18,28" fill="url(#doorSilverOpenGradient)" stroke="hsl(0,100%,50%)" stroke-width="2"/>
+  <polygon points="18,8 26,10 26,30 18,28" fill="url(#doorSilverOpenGradient)" stroke="hsl(0,100%,50%)" stroke-width="2"/>
+  <circle cx="22" cy="20" r="2" fill="hsl(0,100%,50%)" stroke="hsl(0,100%,50%)" stroke-width="1"/>
 </svg>

--- a/assets/floor.svg
+++ b/assets/floor.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="floorGrad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#a66b39"/>
-      <stop offset="100%" stop-color="#6b3f1a"/>
+      <stop offset="0%" stop-color="hsl(28,100%,50%)"/>
+      <stop offset="100%" stop-color="hsl(27,100%,50%)"/>
     </linearGradient>
   </defs>
   <rect width="32" height="32" fill="url(#floorGrad)"/>
-  <path d="M0 8H32M0 16H32M0 24H32" stroke="#5b3214" stroke-width="1"/>
-  <path d="M8 0V32M16 0V32M24 0V32" stroke="#5b3214" stroke-width="1"/>
-  <path d="M4 0V32M12 0V32M20 0V32M28 0V32" stroke="#7d4c26" stroke-width="0.5"/>
+  <path d="M0 8H32M0 16H32M0 24H32" stroke="hsl(25,100%,50%)" stroke-width="1"/>
+  <path d="M8 0V32M16 0V32M24 0V32" stroke="hsl(25,100%,50%)" stroke-width="1"/>
+  <path d="M4 0V32M12 0V32M20 0V32M28 0V32" stroke="hsl(26,100%,50%)" stroke-width="0.5"/>
 </svg>

--- a/assets/hero.svg
+++ b/assets/hero.svg
@@ -1,17 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#aee868"/>
-      <stop offset="100%" stop-color="#6aa84f"/>
+      <stop offset="0%" stop-color="hsl(87,100%,50%)"/>
+      <stop offset="100%" stop-color="hsl(102,100%,50%)"/>
     </linearGradient>
   </defs>
-  <ellipse cx="16" cy="18" rx="12" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
-  <ellipse cx="8" cy="20" rx="4" ry="2" fill="#8cc84b"/>
-  <ellipse cx="24" cy="20" rx="4" ry="2" fill="#8cc84b"/>
-  <circle cx="10" cy="12" r="4" fill="#ffffff"/>
-  <circle cx="22" cy="12" r="4" fill="#ffffff"/>
-  <circle cx="10" cy="12" r="2" fill="#000000"/>
-  <circle cx="22" cy="12" r="2" fill="#000000"/>
-  <path d="M12 18 Q16 22 20 18" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
-  <path d="M8 16 C10 14, 22 14, 24 16" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <ellipse cx="16" cy="18" rx="12" ry="10" fill="url(#frogBody)" stroke="hsl(102,100%,50%)" stroke-width="2"/>
+  <ellipse cx="8" cy="20" rx="4" ry="2" fill="hsl(89,100%,50%)"/>
+  <ellipse cx="24" cy="20" rx="4" ry="2" fill="hsl(89,100%,50%)"/>
+  <circle cx="10" cy="12" r="4" fill="hsl(0,100%,50%)"/>
+  <circle cx="22" cy="12" r="4" fill="hsl(0,100%,50%)"/>
+  <circle cx="10" cy="12" r="2" fill="hsl(0,100%,50%)"/>
+  <circle cx="22" cy="12" r="2" fill="hsl(0,100%,50%)"/>
+  <path d="M12 18 Q16 22 20 18" stroke="hsl(0,100%,50%)" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M8 16 C10 14, 22 14, 24 16" stroke="hsl(0,100%,50%)" stroke-width="3" fill="none" stroke-linecap="round"/>
 </svg>

--- a/assets/key.svg
+++ b/assets/key.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="metal" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#eeeeee"/>
-      <stop offset="100%" stop-color="#bbbbbb"/>
+      <stop offset="0%" stop-color="hsl(0,100%,50%)"/>
+      <stop offset="100%" stop-color="hsl(0,100%,50%)"/>
     </linearGradient>
   </defs>
-  <circle cx="10" cy="16" r="6" fill="url(#metal)" stroke="#999999" stroke-width="2"/>
-  <rect x="14" y="14" width="12" height="4" fill="url(#metal)" stroke="#999999" stroke-width="2"/>
-  <path d="M26 14h4v4h-2v2h-6v-6z" fill="url(#metal)" stroke="#999999" stroke-width="2" stroke-linejoin="round"/>
+  <circle cx="10" cy="16" r="6" fill="url(#metal)" stroke="hsl(0,100%,50%)" stroke-width="2"/>
+  <rect x="14" y="14" width="12" height="4" fill="url(#metal)" stroke="hsl(0,100%,50%)" stroke-width="2"/>
+  <path d="M26 14h4v4h-2v2h-6v-6z" fill="url(#metal)" stroke="hsl(0,100%,50%)" stroke-width="2" stroke-linejoin="round"/>
 </svg>

--- a/assets/treasure.svg
+++ b/assets/treasure.svg
@@ -1,17 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="chestLid" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#ffe08a"/>
-      <stop offset="100%" stop-color="#d4a017"/>
+      <stop offset="0%" stop-color="hsl(44,100%,50%)"/>
+      <stop offset="100%" stop-color="hsl(43,100%,50%)"/>
     </linearGradient>
     <linearGradient id="chestBody" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#d4a017"/>
-      <stop offset="100%" stop-color="#b07c12"/>
+      <stop offset="0%" stop-color="hsl(43,100%,50%)"/>
+      <stop offset="100%" stop-color="hsl(40,100%,50%)"/>
     </linearGradient>
   </defs>
-  <rect x="4" y="14" width="24" height="14" fill="url(#chestBody)" stroke="#996600" stroke-width="2"/>
-  <rect x="4" y="8" width="24" height="10" fill="url(#chestLid)" stroke="#996600" stroke-width="2"/>
-  <line x1="4" y1="16" x2="28" y2="16" stroke="#996600" stroke-width="2"/>
-  <line x1="16" y1="14" x2="16" y2="28" stroke="#b07c12" stroke-width="1"/>
-  <circle cx="16" cy="22" r="2" fill="#996600"/>
+  <rect x="4" y="14" width="24" height="14" fill="url(#chestBody)" stroke="hsl(40,100%,50%)" stroke-width="2"/>
+  <rect x="4" y="8" width="24" height="10" fill="url(#chestLid)" stroke="hsl(40,100%,50%)" stroke-width="2"/>
+  <line x1="4" y1="16" x2="28" y2="16" stroke="hsl(40,100%,50%)" stroke-width="2"/>
+  <line x1="16" y1="14" x2="16" y2="28" stroke="hsl(40,100%,50%)" stroke-width="1"/>
+  <circle cx="16" cy="22" r="2" fill="hsl(40,100%,50%)"/>
 </svg>

--- a/assets/treasure_gold.svg
+++ b/assets/treasure_gold.svg
@@ -1,17 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="chestLid" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#fff7b1"/>
-      <stop offset="100%" stop-color="#ffd700"/>
+      <stop offset="0%" stop-color="hsl(54,100%,50%)"/>
+      <stop offset="100%" stop-color="hsl(51,100%,50%)"/>
     </linearGradient>
     <linearGradient id="chestBody" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#ffd700"/>
-      <stop offset="100%" stop-color="#cfa200"/>
+      <stop offset="0%" stop-color="hsl(51,100%,50%)"/>
+      <stop offset="100%" stop-color="hsl(47,100%,50%)"/>
     </linearGradient>
   </defs>
-  <rect x="4" y="14" width="24" height="14" fill="url(#chestBody)" stroke="#b8860b" stroke-width="2"/>
-  <rect x="4" y="8" width="24" height="10" fill="url(#chestLid)" stroke="#b8860b" stroke-width="2"/>
-  <line x1="4" y1="16" x2="28" y2="16" stroke="#b8860b" stroke-width="2"/>
-  <line x1="16" y1="14" x2="16" y2="28" stroke="#cfa200" stroke-width="1"/>
-  <circle cx="16" cy="22" r="2" fill="#b8860b"/>
+  <rect x="4" y="14" width="24" height="14" fill="url(#chestBody)" stroke="hsl(43,100%,50%)" stroke-width="2"/>
+  <rect x="4" y="8" width="24" height="10" fill="url(#chestLid)" stroke="hsl(43,100%,50%)" stroke-width="2"/>
+  <line x1="4" y1="16" x2="28" y2="16" stroke="hsl(43,100%,50%)" stroke-width="2"/>
+  <line x1="16" y1="14" x2="16" y2="28" stroke="hsl(47,100%,50%)" stroke-width="1"/>
+  <circle cx="16" cy="22" r="2" fill="hsl(43,100%,50%)"/>
 </svg>

--- a/assets/wall.svg
+++ b/assets/wall.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="brickGrad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#777777"/>
-      <stop offset="100%" stop-color="#444444"/>
+      <stop offset="0%" stop-color="hsl(0,100%,50%)"/>
+      <stop offset="100%" stop-color="hsl(0,100%,50%)"/>
     </linearGradient>
   </defs>
   <rect width="32" height="32" fill="url(#brickGrad)"/>
-  <path d="M0 8H32M0 16H32M0 24H32" stroke="#555555" stroke-width="2"/>
-  <path d="M8 0V16M16 0V16M24 0V16M4 16V32M12 16V32M20 16V32M28 16V32" stroke="#555555" stroke-width="2"/>
-  <rect width="32" height="32" fill="none" stroke="#888888" stroke-width="2"/>
+  <path d="M0 8H32M0 16H32M0 24H32" stroke="hsl(0,100%,50%)" stroke-width="2"/>
+  <path d="M8 0V16M16 0V16M24 0V16M4 16V32M12 16V32M20 16V32M28 16V32" stroke="hsl(0,100%,50%)" stroke-width="2"/>
+  <rect width="32" height="32" fill="none" stroke="hsl(0,100%,50%)" stroke-width="2"/>
 </svg>

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="40" fill="#7fd77f" />
-  <circle cx="35" cy="40" r="12" fill="#ffffff" />
-  <circle cx="65" cy="40" r="12" fill="#ffffff" />
-  <circle cx="35" cy="40" r="6" fill="#000000" />
-  <circle cx="65" cy="40" r="6" fill="#000000" />
-  <path d="M30 60 Q50 80 70 60" stroke="#000000" stroke-width="5" fill="none" />
+  <circle cx="50" cy="50" r="40" fill="hsl(120,100%,50%)" />
+  <circle cx="35" cy="40" r="12" fill="hsl(0,100%,50%)" />
+  <circle cx="65" cy="40" r="12" fill="hsl(0,100%,50%)" />
+  <circle cx="35" cy="40" r="6" fill="hsl(0,100%,50%)" />
+  <circle cx="65" cy="40" r="6" fill="hsl(0,100%,50%)" />
+  <path d="M30 60 Q50 80 70 60" stroke="hsl(0,100%,50%)" stroke-width="5" fill="none" />
 </svg>


### PR DESCRIPTION
## Summary
- update all SVG assets with neon style colors expressed in HSL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881c78972248333a90e7c6454a704e7