### PR TITLE
Add brief hero zoom on exit door

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -38,6 +38,14 @@ export default class CameraManager {
   }
 
   /**
+   * 一瞬だけズームインする演出
+   */
+  zoomHeroFocus() {
+    this.cam.zoomTo(1.2, 100)
+      .once('camerazoomcomplete', () => this.cam.zoomTo(1, 150));
+  }
+
+  /**
    * 白フラッシュ
    */
   flashWhite() {

--- a/game.js
+++ b/game.js
@@ -187,6 +187,7 @@ class GameScene extends Phaser.Scene {
         if (this.hero.useKey()) {
           this.updateKeyDisplay();
           this.mazeManager.openDoor(curTile.chunk);
+          this.cameraManager.zoomHeroFocus();
           curTile.chunk.chunk.exited = true;
           gameState.incrementMazeCount();
           gameState.addScore(100);


### PR DESCRIPTION
## Summary
- add `zoomHeroFocus` helper in camera manager for quick zoom-in
- trigger `zoomHeroFocus` when exiting through a door

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6881c7f42d8c83338962556844c52a8d