### PR TITLE
Apply cyberpunk palette to environment SVGs

### DIFF
--- a/assets/arrow.svg
+++ b/assets/arrow.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
-  <path d="M4 16h16" stroke="#ffffff" stroke-width="4" stroke-linecap="round"/>
-  <path d="M16 8l8 8-8 8" fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M4 16h16" stroke="#00ffff" stroke-width="4" stroke-linecap="round"/>
+  <path d="M16 8l8 8-8 8" fill="none" stroke="#00ffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/assets/door_closed.svg
+++ b/assets/door_closed.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="doorGradient" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#ff6666"/>
-      <stop offset="100%" stop-color="#aa0000"/>
+      <stop offset="0%" stop-color="#ff00ff"/>
+      <stop offset="100%" stop-color="#550055"/>
     </linearGradient>
   </defs>
-  <path d="M6 30V10a10 10 0 0120 0v20z" fill="url(#doorGradient)" stroke="#ff9999" stroke-width="2"/>
-  <line x1="16" y1="12" x2="16" y2="28" stroke="#660000" stroke-width="1"/>
-  <circle cx="22" cy="20" r="2" fill="#ffeeee" stroke="#660000" stroke-width="1"/>
+  <path d="M6 30V10a10 10 0 0120 0v20z" fill="url(#doorGradient)" stroke="#ff33ff" stroke-width="2"/>
+  <line x1="16" y1="12" x2="16" y2="28" stroke="#990099" stroke-width="1"/>
+  <circle cx="22" cy="20" r="2" fill="#221122" stroke="#990099" stroke-width="1"/>
 </svg>

--- a/assets/door_open.svg
+++ b/assets/door_open.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="doorOpenGradient" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#ff6666"/>
-      <stop offset="100%" stop-color="#aa0000"/>
+      <stop offset="0%" stop-color="#ff00ff"/>
+      <stop offset="100%" stop-color="#550055"/>
     </linearGradient>
   </defs>
-  <polygon points="6,30 6,10 18,8 18,28" fill="url(#doorOpenGradient)" stroke="#ff9999" stroke-width="2"/>
-  <polygon points="18,8 26,10 26,30 18,28" fill="url(#doorOpenGradient)" stroke="#cc6666" stroke-width="2"/>
-  <circle cx="22" cy="20" r="2" fill="#ffeeee" stroke="#660000" stroke-width="1"/>
+  <polygon points="6,30 6,10 18,8 18,28" fill="url(#doorOpenGradient)" stroke="#ff33ff" stroke-width="2"/>
+  <polygon points="18,8 26,10 26,30 18,28" fill="url(#doorOpenGradient)" stroke="#aa33aa" stroke-width="2"/>
+  <circle cx="22" cy="20" r="2" fill="#221122" stroke="#990099" stroke-width="1"/>
 </svg>

--- a/assets/door_silver.svg
+++ b/assets/door_silver.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="doorSilverGradient" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#cccccc"/>
-      <stop offset="100%" stop-color="#888888"/>
+      <stop offset="0%" stop-color="#00ccff"/>
+      <stop offset="100%" stop-color="#003355"/>
     </linearGradient>
   </defs>
-  <path d="M6 30V10a10 10 0 0120 0v20z" fill="url(#doorSilverGradient)" stroke="#bbbbbb" stroke-width="2"/>
-  <line x1="16" y1="12" x2="16" y2="28" stroke="#555555" stroke-width="1"/>
-  <circle cx="22" cy="20" r="2" fill="#eeeeee" stroke="#555555" stroke-width="1"/>
+  <path d="M6 30V10a10 10 0 0120 0v20z" fill="url(#doorSilverGradient)" stroke="#00ffff" stroke-width="2"/>
+  <line x1="16" y1="12" x2="16" y2="28" stroke="#0088aa" stroke-width="1"/>
+  <circle cx="22" cy="20" r="2" fill="#001122" stroke="#00aaaa" stroke-width="1"/>
 </svg>

--- a/assets/door_silver_open.svg
+++ b/assets/door_silver_open.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="doorSilverOpenGradient" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#cccccc"/>
-      <stop offset="100%" stop-color="#888888"/>
+      <stop offset="0%" stop-color="#00ccff"/>
+      <stop offset="100%" stop-color="#003355"/>
     </linearGradient>
   </defs>
-  <polygon points="6,30 6,10 18,8 18,28" fill="url(#doorSilverOpenGradient)" stroke="#bbbbbb" stroke-width="2"/>
-  <polygon points="18,8 26,10 26,30 18,28" fill="url(#doorSilverOpenGradient)" stroke="#888888" stroke-width="2"/>
-  <circle cx="22" cy="20" r="2" fill="#eeeeee" stroke="#555555" stroke-width="1"/>
+  <polygon points="6,30 6,10 18,8 18,28" fill="url(#doorSilverOpenGradient)" stroke="#00ffff" stroke-width="2"/>
+  <polygon points="18,8 26,10 26,30 18,28" fill="url(#doorSilverOpenGradient)" stroke="#0088aa" stroke-width="2"/>
+  <circle cx="22" cy="20" r="2" fill="#001122" stroke="#00aaaa" stroke-width="1"/>
 </svg>

--- a/assets/floor.svg
+++ b/assets/floor.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="floorGrad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#a66b39"/>
-      <stop offset="100%" stop-color="#6b3f1a"/>
+      <stop offset="0%" stop-color="#222222"/>
+      <stop offset="100%" stop-color="#000000"/>
     </linearGradient>
   </defs>
   <rect width="32" height="32" fill="url(#floorGrad)"/>
-  <path d="M0 8H32M0 16H32M0 24H32" stroke="#5b3214" stroke-width="1"/>
-  <path d="M8 0V32M16 0V32M24 0V32" stroke="#5b3214" stroke-width="1"/>
-  <path d="M4 0V32M12 0V32M20 0V32M28 0V32" stroke="#7d4c26" stroke-width="0.5"/>
+  <path d="M0 8H32M0 16H32M0 24H32" stroke="#005577" stroke-width="1"/>
+  <path d="M8 0V32M16 0V32M24 0V32" stroke="#005577" stroke-width="1"/>
+  <path d="M4 0V32M12 0V32M20 0V32M28 0V32" stroke="#0099aa" stroke-width="0.5"/>
 </svg>

--- a/assets/key.svg
+++ b/assets/key.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="metal" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#eeeeee"/>
-      <stop offset="100%" stop-color="#bbbbbb"/>
+      <stop offset="0%" stop-color="#00ffff"/>
+      <stop offset="100%" stop-color="#004466"/>
     </linearGradient>
   </defs>
-  <circle cx="10" cy="16" r="6" fill="url(#metal)" stroke="#999999" stroke-width="2"/>
-  <rect x="14" y="14" width="12" height="4" fill="url(#metal)" stroke="#999999" stroke-width="2"/>
-  <path d="M26 14h4v4h-2v2h-6v-6z" fill="url(#metal)" stroke="#999999" stroke-width="2" stroke-linejoin="round"/>
+  <circle cx="10" cy="16" r="6" fill="url(#metal)" stroke="#00cccc" stroke-width="2"/>
+  <rect x="14" y="14" width="12" height="4" fill="url(#metal)" stroke="#00cccc" stroke-width="2"/>
+  <path d="M26 14h4v4h-2v2h-6v-6z" fill="url(#metal)" stroke="#00cccc" stroke-width="2" stroke-linejoin="round"/>
 </svg>

--- a/assets/treasure.svg
+++ b/assets/treasure.svg
@@ -1,17 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="chestLid" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#ffe08a"/>
-      <stop offset="100%" stop-color="#d4a017"/>
+      <stop offset="0%" stop-color="#00ffff"/>
+      <stop offset="100%" stop-color="#0066ff"/>
     </linearGradient>
     <linearGradient id="chestBody" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#d4a017"/>
-      <stop offset="100%" stop-color="#b07c12"/>
+      <stop offset="0%" stop-color="#0066ff"/>
+      <stop offset="100%" stop-color="#002244"/>
     </linearGradient>
   </defs>
-  <rect x="4" y="14" width="24" height="14" fill="url(#chestBody)" stroke="#996600" stroke-width="2"/>
-  <rect x="4" y="8" width="24" height="10" fill="url(#chestLid)" stroke="#996600" stroke-width="2"/>
-  <line x1="4" y1="16" x2="28" y2="16" stroke="#996600" stroke-width="2"/>
-  <line x1="16" y1="14" x2="16" y2="28" stroke="#b07c12" stroke-width="1"/>
-  <circle cx="16" cy="22" r="2" fill="#996600"/>
+  <rect x="4" y="14" width="24" height="14" fill="url(#chestBody)" stroke="#00aaff" stroke-width="2"/>
+  <rect x="4" y="8" width="24" height="10" fill="url(#chestLid)" stroke="#00aaff" stroke-width="2"/>
+  <line x1="4" y1="16" x2="28" y2="16" stroke="#00aaff" stroke-width="2"/>
+  <line x1="16" y1="14" x2="16" y2="28" stroke="#004477" stroke-width="1"/>
+  <circle cx="16" cy="22" r="2" fill="#00aaff"/>
 </svg>

--- a/assets/treasure_gold.svg
+++ b/assets/treasure_gold.svg
@@ -1,17 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="chestLid" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#fff7b1"/>
-      <stop offset="100%" stop-color="#ffd700"/>
+      <stop offset="0%" stop-color="#ffff66"/>
+      <stop offset="100%" stop-color="#ffcc00"/>
     </linearGradient>
     <linearGradient id="chestBody" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#ffd700"/>
-      <stop offset="100%" stop-color="#cfa200"/>
+      <stop offset="0%" stop-color="#ffcc00"/>
+      <stop offset="100%" stop-color="#664400"/>
     </linearGradient>
   </defs>
-  <rect x="4" y="14" width="24" height="14" fill="url(#chestBody)" stroke="#b8860b" stroke-width="2"/>
-  <rect x="4" y="8" width="24" height="10" fill="url(#chestLid)" stroke="#b8860b" stroke-width="2"/>
-  <line x1="4" y1="16" x2="28" y2="16" stroke="#b8860b" stroke-width="2"/>
-  <line x1="16" y1="14" x2="16" y2="28" stroke="#cfa200" stroke-width="1"/>
-  <circle cx="16" cy="22" r="2" fill="#b8860b"/>
+  <rect x="4" y="14" width="24" height="14" fill="url(#chestBody)" stroke="#ffdd33" stroke-width="2"/>
+  <rect x="4" y="8" width="24" height="10" fill="url(#chestLid)" stroke="#ffdd33" stroke-width="2"/>
+  <line x1="4" y1="16" x2="28" y2="16" stroke="#ffdd33" stroke-width="2"/>
+  <line x1="16" y1="14" x2="16" y2="28" stroke="#664400" stroke-width="1"/>
+  <circle cx="16" cy="22" r="2" fill="#ffdd33"/>
 </svg>

--- a/assets/wall.svg
+++ b/assets/wall.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="brickGrad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#777777"/>
-      <stop offset="100%" stop-color="#444444"/>
+      <stop offset="0%" stop-color="#333333"/>
+      <stop offset="100%" stop-color="#000000"/>
     </linearGradient>
   </defs>
   <rect width="32" height="32" fill="url(#brickGrad)"/>
-  <path d="M0 8H32M0 16H32M0 24H32" stroke="#555555" stroke-width="2"/>
-  <path d="M8 0V16M16 0V16M24 0V16M4 16V32M12 16V32M20 16V32M28 16V32" stroke="#555555" stroke-width="2"/>
-  <rect width="32" height="32" fill="none" stroke="#888888" stroke-width="2"/>
+  <path d="M0 8H32M0 16H32M0 24H32" stroke="#00aaff" stroke-width="2"/>
+  <path d="M8 0V16M16 0V16M24 0V16M4 16V32M12 16V32M20 16V32M28 16V32" stroke="#00aaff" stroke-width="2"/>
+  <rect width="32" height="32" fill="none" stroke="#00ffff" stroke-width="2"/>
 </svg>


### PR DESCRIPTION
## Summary
- redesign arrow, doors, key, treasure chest, wall, and floor graphics with neon gradients
- leave hero graphics untouched

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6881c9af1228833389849f4f334b4bc6