### PR TITLE
Add sound effects to gameplay

### DIFF
--- a/maze_manager.js
+++ b/maze_manager.js
@@ -146,6 +146,7 @@ export default class MazeManager {
           duration: this.fadeDuration,
           onComplete: () => {
             if (this.isHeroInside(hero, obj)) {
+              this.scene.sound.play('game_over');
               this.scene.scene.restart();
             }
             obj.container.destroy();


### PR DESCRIPTION
## Summary
- load all sound assets in game preload
- play chunk creation sounds for the first and subsequent mazes
- add walk, chest, door, midpoint and game‑over effects

## Testing
- `node --check game.js && node --check maze_manager.js`


------
https://chatgpt.com/codex/tasks/task_e_68822695cacc8333b40fcfa667c766f1