### PR TITLE
Improve milestone flash

### DIFF
--- a/game.js
+++ b/game.js
@@ -8,6 +8,8 @@ import InputBuffer from './input_buffer.js';
 import UIScene from './ui_scene.js';
 import { newChunkTransition } from './effects.js';
 
+const MIDPOINTS = [5, 10, 15, 20, 30, 40, 50];
+
 const VIRTUAL_WIDTH = 480;
 const VIRTUAL_HEIGHT = 270;
 
@@ -18,7 +20,6 @@ class GameScene extends Phaser.Scene {
   constructor() {
     super('GameScene');
     this.isMoving = false;
-    this.midpointPlayed = false;
   }
 
   preload() {
@@ -212,9 +213,12 @@ class GameScene extends Phaser.Scene {
           this.cameraManager.zoomHeroFocus();
           curTile.chunk.chunk.exited = true;
           gameState.incrementMazeCount();
-          if (!this.midpointPlayed && gameState.clearedMazes >= 5) {
-            this.midpointPlayed = true;
+          if (MIDPOINTS.includes(gameState.clearedMazes)) {
             this.sound.play('midpoint');
+            const ui = this.scene.get('UIScene');
+            if (ui && ui.showMidpoint) {
+              ui.showMidpoint(gameState.clearedMazes);
+            }
           }
           this.events.emit('updateChunks', gameState.clearedMazes);
           this.events.emit('updateKeys', this.hero.keys);

--- a/ui_scene.js
+++ b/ui_scene.js
@@ -43,4 +43,42 @@ export default class UIScene extends Phaser.Scene {
     // Right pad with spaces to keep label position stable
     this.chunkText.setText('CHUNK ' + count.toString());
   }
+
+  showMidpoint(num) {
+    const flash = this.add.rectangle(
+      VIRTUAL_WIDTH,
+      VIRTUAL_HEIGHT,
+      VIRTUAL_WIDTH * 2,
+      12,
+      0xffffff
+    ).setOrigin(0.5);
+    flash.setDepth(999);
+    flash.setBlendMode(Phaser.BlendModes.ADD);
+    this.tweens.add({
+      targets: flash,
+      scaleX: 2,
+      alpha: 0,
+      duration: 400,
+      ease: 'Cubic.easeOut',
+      onComplete: () => flash.destroy()
+    });
+
+    const text = this.add.text(VIRTUAL_WIDTH, VIRTUAL_HEIGHT, num.toString(), {
+      fontFamily: 'monospace',
+      fontSize: '192px',
+      stroke: '#000000',
+      strokeThickness: 4
+    }).setOrigin(0.5);
+    text.setDepth(1000);
+    text.setShadow(4, 4, '#000000', 4, true, true);
+    text.setTintFill(0xffffff, 0xffffff, 0xffffff, 0xcd853f);
+    this.tweens.add({
+      targets: text,
+      scale: 2,
+      alpha: 0,
+      duration: 1000,
+      ease: 'Quad.easeOut',
+      onComplete: () => text.destroy()
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- play milestone effect on specific chunk counts
- reduce outline and adjust gradient tint for milestone numbers
- add horizontal flash behind milestone text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68822ac83bbc83338bab71f6342173e7