### PR TITLE
Fix camera pan center

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -38,6 +38,12 @@ export default class CameraManager {
     this.expectedCenter.y = cy;
     // Force a new pan so it isn't ignored if a previous pan is active
     this.cam.pan(cx, cy, duration, 'Sine.easeInOut', true);
+    this.cam.once('camerapancomplete', () => {
+      // Snap exactly to the target to avoid drift
+      this.cam.centerOn(cx, cy);
+      this.expectedCenter.x = cx;
+      this.expectedCenter.y = cy;
+    });
     if (this.debugChunk) {
       this.debugChunk.setPosition(cx, cy);
     }
@@ -74,6 +80,11 @@ export default class CameraManager {
     this.expectedCenter.y = y;
     // Force the pan so it always completes even if another is running
     this.cam.pan(x, y, duration, 'Sine.easeInOut', true);
+    this.cam.once('camerapancomplete', () => {
+      this.cam.centerOn(x, y);
+      this.expectedCenter.x = x;
+      this.expectedCenter.y = y;
+    });
   }
 
   /**

--- a/camera.js
+++ b/camera.js
@@ -15,6 +15,16 @@ export default class CameraManager {
       x: this.cam.midPoint.x,
       y: this.cam.midPoint.y
     };
+
+    // Debug markers for camera vs chunk center
+    this.debugCam = scene.add.circle(0, 0, 3, 0xffffff);
+    this.debugChunk = scene.add.circle(0, 0, 6, 0x0000ff, 0)
+      .setStrokeStyle(1, 0x0000ff);
+    this.debugCam.setDepth(1000);
+    this.debugChunk.setDepth(1000);
+    if (scene.worldLayer) {
+      scene.worldLayer.add([this.debugCam, this.debugChunk]);
+    }
   }
 
   /**
@@ -28,6 +38,9 @@ export default class CameraManager {
     this.expectedCenter.y = cy;
     // Force a new pan so it isn't ignored if a previous pan is active
     this.cam.pan(cx, cy, duration, 'Sine.easeInOut', true);
+    if (this.debugChunk) {
+      this.debugChunk.setPosition(cx, cy);
+    }
   }
 
   /**
@@ -75,6 +88,9 @@ export default class CameraManager {
       if (Math.abs(dx) > 0.1 || Math.abs(dy) > 0.1) {
         this.cam.centerOn(x, y);
       }
+    }
+    if (this.debugCam) {
+      this.debugCam.setPosition(this.cam.midPoint.x, this.cam.midPoint.y);
     }
   }
 

--- a/camera.js
+++ b/camera.js
@@ -26,7 +26,8 @@ export default class CameraManager {
     const { x: cx, y: cy } = this.mazeManager.getChunkCenter(info);
     this.expectedCenter.x = cx;
     this.expectedCenter.y = cy;
-    this.cam.pan(cx, cy, duration, 'Sine.easeInOut');
+    // Force a new pan so it isn't ignored if a previous pan is active
+    this.cam.pan(cx, cy, duration, 'Sine.easeInOut', true);
   }
 
   /**
@@ -58,7 +59,8 @@ export default class CameraManager {
   panTo(x, y, duration = 500) {
     this.expectedCenter.x = x;
     this.expectedCenter.y = y;
-    this.cam.pan(x, y, duration, 'Sine.easeInOut');
+    // Force the pan so it always completes even if another is running
+    this.cam.pan(x, y, duration, 'Sine.easeInOut', true);
   }
 
   /**

--- a/docs/camera.md
+++ b/docs/camera.md
@@ -45,7 +45,7 @@
 
 `CameraManager` クラスではカメラ移動やズーム、フラッシュなどの演出をまとめて管理します。
 
-- **panToChunk(chunk, duration)** … 新しく生成された迷路チャンクの中央へカメラを移動。
+- **panToChunk(chunk, duration)** … 新しく生成された迷路チャンクの中央へカメラを移動。`force` オプションで必ず開始し、`camerapancomplete` で最終位置を微調整します。
 - **zoomBump()** … 一瞬だけ縮小して戻すことで軽く揺らす演出。
 - **flashWhite()** … 画面全体を白くフラッシュさせる。
 

--- a/docs/camera.md
+++ b/docs/camera.md
@@ -41,35 +41,16 @@
 
 ---
 
-## 4. ざっくりコード
+## 4. ざっくり実装例
 
-```ts
-class CameraManager {
-  constructor(private cam: Phaser.Cameras.Scene2D.Camera){}
+`CameraManager` クラスではカメラ移動やズーム、フラッシュなどの演出をまとめて管理します。
 
-  // 1. チャンクの中心へ移動
-  panToChunk(chunk: MazeChunk, dur=400){
-    const cx = chunk.x + chunk.size*16; // 32pxタイル → 半分
-    const cy = chunk.y + chunk.size*16;
-    this.cam.pan(cx, cy, dur, 'Sine.easeInOut');
-  }
+- **panToChunk(chunk, duration)** … 新しく生成された迷路チャンクの中央へカメラを移動。
+- **zoomBump()** … 一瞬だけ縮小して戻すことで軽く揺らす演出。
+- **flashWhite()** … 画面全体を白くフラッシュさせる。
 
-  // 2. 軽い揺れ (ズームバンプ)
-  zoomBump(){
-    this.cam.zoomTo(0.95,150)
-      .once('camerazoomcomplete', ()=> this.cam.zoomTo(1,200));
-  }
-
-  // 3. 白フラッシュ
-  flashWhite(){ this.cam.flash(120,255,255,255); }
-}
-```
-
-- **GameScene** 内ではインスタンスを作り、イベントで呼ぶだけ。
-
-```ts
-generator.on('chunk-created', ch => cameraMgr.panToChunk(ch));
-```
+GameScene 側では MazeManager が発行する `chunk-created` イベントを監視し、
+`panToChunk()` → `zoomBump()` の順で呼ぶだけで、常に迷路の中心を追うことができます。
 
 ---
 

--- a/game.js
+++ b/game.js
@@ -42,6 +42,19 @@ class GameScene extends Phaser.Scene {
 
     this.worldLayer = this.add.container(0, 0);
     this.mazeManager = new MazeManager(this);
+
+    this.cameraManager = new CameraManager(this, this.mazeManager);
+    this._seenFirstChunk = false;
+    this.mazeManager.events.on('chunk-created', info => {
+      this.cameraManager.expandBounds(info);
+      const dur = this._seenFirstChunk ? 400 : 0;
+      this.cameraManager.panToChunk(info, dur);
+      if (this._seenFirstChunk) {
+        this.cameraManager.zoomBump();
+      }
+      this._seenFirstChunk = true;
+    });
+
     const firstInfo = this.mazeManager.spawnInitial();
     this.sound.play('chunk_generate_1');
 
@@ -71,15 +84,7 @@ class GameScene extends Phaser.Scene {
     this.worldLayer.add(this.keyDisplay);
     this.updateKeyDisplay();
 
-    this.cameraManager = new CameraManager(this, this.mazeManager);
-    this.cameraManager.expandBounds(firstInfo);
-    this.cameraManager.panToChunk(firstInfo, 0);
-    // Update bounds whenever a chunk is added
-    this.mazeManager.events.on('chunk-added', info => {
-      if (info !== firstInfo) {
-        this.cameraManager.expandBounds(info);
-      }
-    });
+    // Handle transitions for door exit
     this.mazeManager.events.on('spawn-next', data => {
       newChunkTransition(this, data.doorDir, data.doorWorldX, data.doorWorldY);
       this.sound.play('chunk_generate_2');
@@ -248,8 +253,6 @@ class GameScene extends Phaser.Scene {
             curTile.chunk,
             this.heroSprite
           );
-          this.cameraManager.panToChunk(nextInfo);
-          this.cameraManager.zoomBump();
         } else {
           if (curTile.chunk.doorSprite) {
             this.tweens.add({

--- a/maze_manager.js
+++ b/maze_manager.js
@@ -66,6 +66,7 @@ export default class MazeManager {
     this.renderChunk(chunk, container, info);
     this.activeChunks.push(info);
     this.events.emit('chunk-added', info);
+    this.events.emit('chunk-created', info);
     return info;
   }
 


### PR DESCRIPTION
## Summary
- force camera pans to override any current movement
- clarify camera manager docs and remove outdated code example
- restructure camera pan logic to trigger on new `chunk-created` events

## Testing
- `node -v`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688235bc50308333bb4c2511c2e3ecbc