### PR TITLE
Add loading screen with dissolve effect

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -79,3 +79,27 @@ export function evaporateChunk(scene, x, y, width, height) {
     });
   }
 }
+
+// Generic evaporate effect for arbitrary rectangular areas
+export function evaporateArea(scene, x, y, width, height, color = 0xffffff) {
+  const PARTICLES = 30;
+  const SIZE = 4;
+  for (let i = 0; i < PARTICLES; i++) {
+    const px = x + Math.random() * width;
+    const py = y + Math.random() * height;
+    const chip = scene.add.rectangle(px, py, SIZE, SIZE, color);
+    chip.setDepth(1000);
+    const dx = (Math.random() - 0.5) * 40;
+    const dy = -30 - Math.random() * 30;
+    scene.tweens.add({
+      targets: chip,
+      x: chip.x + dx,
+      y: chip.y + dy,
+      alpha: 0,
+      scale: 0,
+      duration: 600,
+      ease: 'Quad.easeOut',
+      onComplete: () => chip.destroy()
+    });
+  }
+}

--- a/game.js
+++ b/game.js
@@ -7,6 +7,7 @@ import Characters from './characters.js';
 import InputBuffer from './input_buffer.js';
 import UIScene from './ui_scene.js';
 import { newChunkTransition } from './effects.js';
+import LoadingScene from './loading_scene.js';
 
 const MIDPOINTS = [5, 10, 15, 20, 30, 40, 50];
 
@@ -27,13 +28,6 @@ class GameScene extends Phaser.Scene {
 
   preload() {
     Characters.registerTextures(this);
-    this.load.audio('hero_walk', 'assets/sounds/01_hero_walk.wav');
-    this.load.audio('door_open', 'assets/sounds/02_door_open.mp3');
-    this.load.audio('chest_open', 'assets/sounds/03_chest_open.wav');
-    this.load.audio('chunk_generate_1', 'assets/sounds/04_chunk_generate_1.wav');
-    this.load.audio('chunk_generate_2', 'assets/sounds/05_chunk_generate_02.wav');
-    this.load.audio('midpoint', 'assets/sounds/06_midpoint.wav');
-    this.load.audio('game_over', 'assets/sounds/07_game_over.wav');
   }
 
   create() {
@@ -302,7 +296,7 @@ const config = {
     width: VIRTUAL_WIDTH * 2,
     height: VIRTUAL_HEIGHT * 2
   },
-  scene: [GameScene, UIScene]
+  scene: [LoadingScene, GameScene, UIScene]
 };
 
 Characters.ready.then(() => {

--- a/loading_scene.js
+++ b/loading_scene.js
@@ -1,0 +1,72 @@
+// LoadingScene handles initial asset loading and displays a loading overlay.
+import Characters from './characters.js';
+import { evaporateArea } from './effects.js';
+
+const VIRTUAL_WIDTH = 480;
+const VIRTUAL_HEIGHT = 270;
+
+export default class LoadingScene extends Phaser.Scene {
+  constructor() {
+    super('LoadingScene');
+  }
+
+  preload() {
+    // Register textures that were preloaded via Characters.ready
+    Characters.registerTextures(this);
+
+    // Full screen black mask
+    this.mask = this.add.rectangle(0, 0, VIRTUAL_WIDTH * 2, VIRTUAL_HEIGHT * 2, 0x000000)
+      .setOrigin(0);
+    this.mask.setDepth(1000);
+
+    // "NOW LOADING" label
+    this.loadingText = this.add.text(VIRTUAL_WIDTH, VIRTUAL_HEIGHT, 'NOW LOADING', {
+      fontFamily: 'monospace',
+      fontSize: '32px',
+      color: '#ffffff'
+    }).setOrigin(0.5);
+    this.loadingText.setDepth(1001);
+
+    // Audio assets
+    this.load.audio('hero_walk', 'assets/sounds/01_hero_walk.wav');
+    this.load.audio('door_open', 'assets/sounds/02_door_open.mp3');
+    this.load.audio('chest_open', 'assets/sounds/03_chest_open.wav');
+    this.load.audio('chunk_generate_1', 'assets/sounds/04_chunk_generate_1.wav');
+    this.load.audio('chunk_generate_2', 'assets/sounds/05_chunk_generate_02.wav');
+    this.load.audio('midpoint', 'assets/sounds/06_midpoint.wav');
+    this.load.audio('game_over', 'assets/sounds/07_game_over.wav');
+  }
+
+  create() {
+    // Launch the main scenes behind the loading overlay
+    this.scene.launch('GameScene');
+    this.scene.launch('UIScene');
+    this.scene.bringToTop();
+
+    // Short delay to ensure GameScene is ready before removing overlay
+    this.time.delayedCall(200, () => {
+      // Evaporate loading text
+      evaporateArea(
+        this,
+        this.loadingText.x - this.loadingText.width / 2,
+        this.loadingText.y - this.loadingText.height / 2,
+        this.loadingText.width,
+        this.loadingText.height,
+        0xffffff
+      );
+      this.loadingText.destroy();
+
+      // Evaporate mask after text
+      evaporateArea(this, 0, 0, VIRTUAL_WIDTH * 2, VIRTUAL_HEIGHT * 2, 0x000000);
+      this.tweens.add({
+        targets: this.mask,
+        alpha: 0,
+        duration: 500,
+        onComplete: () => {
+          this.mask.destroy();
+          this.scene.stop();
+        }
+      });
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add new `LoadingScene` to display a black mask with **NOW LOADING** text
- implement `evaporateArea` effect for dissolving rectangles
- start main scenes from the loader and dissolve text/mask once loading completes
- adjust `GameScene` preload and config to use the new loading scene

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6882485424a88333ad515f863187a0ab