### PR TITLE
Update hero SVG with spacesuit

### DIFF
--- a/assets/images/hero.svg
+++ b/assets/images/hero.svg
@@ -5,6 +5,8 @@
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
   </defs>
+  <!-- Suit Body -->
+  <ellipse cx="16" cy="25" rx="8" ry="9" fill="#e0e0e0" stroke="#b0b0b0" stroke-width="2"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Legs -->
@@ -20,4 +22,6 @@
   <circle cx="22" cy="6" r="2" fill="#000000"/>
   <path d="M12 12 Q16 16 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
   <path d="M8 10 C10 8, 22 8, 24 10" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Helmet -->
+  <circle cx="16" cy="12" r="12" fill="#e0f7ff" fill-opacity="0.5" stroke="#99ccff" stroke-width="2"/>
 </svg>

--- a/assets/images/hero_walk1.svg
+++ b/assets/images/hero_walk1.svg
@@ -5,6 +5,8 @@
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
   </defs>
+  <!-- Suit Body -->
+  <ellipse cx="16" cy="25" rx="8" ry="9" fill="#e0e0e0" stroke="#b0b0b0" stroke-width="2"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Legs -->
@@ -20,4 +22,6 @@
   <circle cx="22" cy="6" r="2" fill="#000000"/>
   <path d="M12 12 Q16 16 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
   <path d="M8 10 C10 8, 22 8, 24 10" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Helmet -->
+  <circle cx="16" cy="12" r="12" fill="#e0f7ff" fill-opacity="0.5" stroke="#99ccff" stroke-width="2"/>
 </svg>

--- a/assets/images/hero_walk2.svg
+++ b/assets/images/hero_walk2.svg
@@ -5,6 +5,8 @@
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
   </defs>
+  <!-- Suit Body -->
+  <ellipse cx="16" cy="25" rx="8" ry="9" fill="#e0e0e0" stroke="#b0b0b0" stroke-width="2"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Legs -->
@@ -20,4 +22,6 @@
   <circle cx="22" cy="6" r="2" fill="#000000"/>
   <path d="M12 12 Q16 16 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
   <path d="M8 10 C10 8, 22 8, 24 10" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Helmet -->
+  <circle cx="16" cy="12" r="12" fill="#e0f7ff" fill-opacity="0.5" stroke="#99ccff" stroke-width="2"/>
 </svg>

--- a/assets/images/hero_walk3.svg
+++ b/assets/images/hero_walk3.svg
@@ -5,6 +5,8 @@
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
   </defs>
+  <!-- Suit Body -->
+  <ellipse cx="16" cy="25" rx="8" ry="9" fill="#e0e0e0" stroke="#b0b0b0" stroke-width="2"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Legs -->
@@ -20,4 +22,6 @@
   <circle cx="22" cy="6" r="2" fill="#000000"/>
   <path d="M12 12 Q16 16 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
   <path d="M8 10 C10 8, 22 8, 24 10" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Helmet -->
+  <circle cx="16" cy="12" r="12" fill="#e0f7ff" fill-opacity="0.5" stroke="#99ccff" stroke-width="2"/>
 </svg>


### PR DESCRIPTION
## Summary
- add a spacesuit ellipse around the body for hero sprites
- add a transparent helmet circle around the head for hero sprites

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68825e8f8c8c8333a85ae434a9dcf201