### PR TITLE
Switch to key icons for chests

### DIFF
--- a/maze_manager.js
+++ b/maze_manager.js
@@ -104,7 +104,8 @@ export default class MazeManager {
             break;
           case TILE.CHEST:
           case TILE.ITEM_CHEST:
-            sprite = Characters.createTreasure(this.scene);
+            // Display a key icon instead of a treasure chest
+            sprite = Characters.createKey(this.scene);
             info.chestSprite = sprite;
             info.chestPosition = { x, y };
             break;


### PR DESCRIPTION
## Summary
- change chest tile sprite from treasure chest to key

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6882675f69f08333985e25621f164888