### PR TITLE
Add star field background

### DIFF
--- a/game.js
+++ b/game.js
@@ -8,6 +8,7 @@ import InputBuffer from './input_buffer.js';
 import UIScene from './ui_scene.js';
 import { newChunkTransition, evaporateArea } from './effects.js';
 import LoadingScene from './loading_scene.js';
+import StarField from './star_field.js';
 
 const MIDPOINTS = [5, 10, 15, 20, 30, 40, 50];
 
@@ -39,6 +40,7 @@ class GameScene extends Phaser.Scene {
     this.mazeManager = new MazeManager(this);
 
     this.cameraManager = new CameraManager(this, this.mazeManager);
+    this.starField = new StarField(this, this.cameraManager.bounds);
     this._seenFirstChunk = false;
     this.mazeManager.events.on('chunk-created', info => {
       this.cameraManager.expandBounds(info);

--- a/game.js
+++ b/game.js
@@ -40,7 +40,7 @@ class GameScene extends Phaser.Scene {
     this.mazeManager = new MazeManager(this);
 
     this.cameraManager = new CameraManager(this, this.mazeManager);
-    this.starField = new StarField(this, this.cameraManager.bounds);
+    this.starField = new StarField(this);
     this._seenFirstChunk = false;
     this.mazeManager.events.on('chunk-created', info => {
       this.cameraManager.expandBounds(info);

--- a/star_field.js
+++ b/star_field.js
@@ -1,12 +1,15 @@
 export default class StarField {
-  constructor(scene, bounds, count = 300) {
+  constructor(scene, count = 200) {
     this.scene = scene;
+    const cam = scene.cameras.main;
+    const width = cam.width;
+    const height = cam.height;
     this.container = scene.add.container(0, 0);
     this.container.setDepth(-1000);
-    const b = bounds || { minX: -1000, minY: -1000, maxX: 9000, maxY: 9000 };
+    this.container.setScrollFactor(0);
     for (let i = 0; i < count; i++) {
-      const x = Phaser.Math.Between(b.minX, b.maxX);
-      const y = Phaser.Math.Between(b.minY, b.maxY);
+      const x = Phaser.Math.Between(0, width);
+      const y = Phaser.Math.Between(0, height);
       const star = scene.add.rectangle(x, y, 2, 2, 0xffffff);
       this.container.add(star);
       scene.tweens.add({

--- a/star_field.js
+++ b/star_field.js
@@ -1,0 +1,23 @@
+export default class StarField {
+  constructor(scene, bounds, count = 300) {
+    this.scene = scene;
+    this.container = scene.add.container(0, 0);
+    this.container.setDepth(-1000);
+    const b = bounds || { minX: -1000, minY: -1000, maxX: 9000, maxY: 9000 };
+    for (let i = 0; i < count; i++) {
+      const x = Phaser.Math.Between(b.minX, b.maxX);
+      const y = Phaser.Math.Between(b.minY, b.maxY);
+      const star = scene.add.rectangle(x, y, 2, 2, 0xffffff);
+      this.container.add(star);
+      scene.tweens.add({
+        targets: star,
+        alpha: { from: 0.3, to: 1 },
+        duration: Phaser.Math.Between(800, 2000),
+        ease: 'Sine.easeInOut',
+        yoyo: true,
+        repeat: -1,
+        delay: Phaser.Math.Between(0, 2000)
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `StarField` module to draw many twinkling stars
- load the new module in `game.js` and construct a star field when the game scene starts

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68826f3f0d988333bba6330636c35e20