### PR TITLE
Set default camera zoom to 2x

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -3,6 +3,8 @@ export default class CameraManager {
     this.scene = scene;
     this.mazeManager = mazeManager;
     this.cam = scene.cameras.main;
+    // Start a bit closer to make the maze appear larger
+    this.cam.setZoom(2);
     this.bounds = { minX: -1000, minY: -1000, maxX: 9000, maxY: 9000 };
     this.cam.setBounds(
       this.bounds.minX,


### PR DESCRIPTION
## Summary
- bring the main camera closer so the maze appears twice as large

## Testing
- `npx --yes serve` *(fails: no tests, manual run not performed)*

------
https://chatgpt.com/codex/tasks/task_e_6882dfaff39c8333b571a3e661de72ad