### PR TITLE
Add O2 label to air tank icon

### DIFF
--- a/assets/images/air_tank.svg
+++ b/assets/images/air_tank.svg
@@ -30,11 +30,14 @@
     <circle cx="32" cy="50" r="10" fill="#ffffff" stroke="#2b6f95" stroke-width="2"/>
     <line x1="32" y1="50" x2="38" y2="46" stroke="#2b6f95" stroke-width="2"/>
   </g>
-  <!-- O2 label -->
-  <text x="32" y="8" text-anchor="middle" font-size="8" font-family="Arial" fill="#2b6f95">O2</text>
   <!-- Decorative stripes -->
   <g>
     <rect x="12" y="50" width="40" height="8" fill="#81c6ff"/>
     <rect x="12" y="72" width="40" height="8" fill="#81c6ff"/>
   </g>
+  <!-- O2 label overlay -->
+  <text x="32" y="64" text-anchor="middle" dominant-baseline="middle"
+        textLength="64" lengthAdjust="spacingAndGlyphs"
+        font-family="Arial" font-weight="bold" font-size="60"
+        fill="#ffffff" stroke="#000000" stroke-width="2" paint-order="stroke">O2</text>
 </svg>

--- a/assets/images/air_tank.svg
+++ b/assets/images/air_tank.svg
@@ -30,6 +30,8 @@
     <circle cx="32" cy="50" r="10" fill="#ffffff" stroke="#2b6f95" stroke-width="2"/>
     <line x1="32" y1="50" x2="38" y2="46" stroke="#2b6f95" stroke-width="2"/>
   </g>
+  <!-- O2 label -->
+  <text x="32" y="8" text-anchor="middle" font-size="8" font-family="Arial" fill="#2b6f95">O2</text>
   <!-- Decorative stripes -->
   <g>
     <rect x="12" y="50" width="40" height="8" fill="#81c6ff"/>


### PR DESCRIPTION
## Summary
- update `air_tank.svg` so the oxygen tank icon shows an `O2` label

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6882e152ad5c83338850145a8f75dd23