### PR TITLE
Update O2 label to O₂ with thicker outline

### DIFF
--- a/assets/images/air_tank.svg
+++ b/assets/images/air_tank.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
   <defs>
     <linearGradient id="tankBody" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#c6ecff"/>
@@ -14,28 +14,28 @@
   </defs>
   <!-- Tank body -->
   <g filter="url(#shadow)">
-    <rect x="9" y="8" width="14" height="18" rx="4" fill="url(#tankBody)" stroke="#2b6f95" stroke-width="1.5"/>
-    <rect x="9" y="8" width="14" height="18" rx="4" fill="url(#tankHighlight)"/>
+    <rect x="5" y="6" width="22" height="22" rx="4" fill="url(#tankBody)" stroke="#2b6f95" stroke-width="1.5"/>
+    <rect x="5" y="6" width="22" height="22" rx="4" fill="url(#tankHighlight)"/>
   </g>
   <!-- Valve -->
   <g filter="url(#shadow)">
-    <rect x="13" y="4" width="6" height="4" rx="1" fill="#4dd0e1" stroke="#2b6f95" stroke-width="1.5"/>
-    <circle cx="16" cy="6" r="2" fill="#ffffff" stroke="#2b6f95" stroke-width="1.5"/>
-    <line x1="16" y1="6" x2="16" y2="4" stroke="#2b6f95" stroke-width="1.5"/>
-    <line x1="16" y1="6" x2="18" y2="6" stroke="#2b6f95" stroke-width="1.5"/>
+    <rect x="13" y="2" width="6" height="4" rx="1" fill="#4dd0e1" stroke="#2b6f95" stroke-width="1.5"/>
+    <circle cx="16" cy="4" r="2" fill="#ffffff" stroke="#2b6f95" stroke-width="1.5"/>
+    <line x1="16" y1="4" x2="16" y2="2" stroke="#2b6f95" stroke-width="1.5"/>
+    <line x1="16" y1="4" x2="18" y2="4" stroke="#2b6f95" stroke-width="1.5"/>
   </g>
   <!-- Gauge -->
   <g filter="url(#shadow)">
-    <circle cx="16" cy="18" r="4" fill="#ffffff" stroke="#2b6f95" stroke-width="1.5"/>
-    <line x1="16" y1="18" x2="19" y2="17" stroke="#2b6f95" stroke-width="1.5"/>
+    <circle cx="16" cy="18" r="5" fill="#ffffff" stroke="#2b6f95" stroke-width="1.5"/>
+    <line x1="16" y1="18" x2="20" y2="16" stroke="#2b6f95" stroke-width="1.5"/>
   </g>
   <!-- Decorative stripes -->
   <g>
-    <rect x="9" y="18" width="14" height="2" fill="#81c6ff"/>
-    <rect x="9" y="22" width="14" height="2" fill="#81c6ff"/>
+    <rect x="5" y="18" width="22" height="2" fill="#81c6ff"/>
+    <rect x="5" y="22" width="22" height="2" fill="#81c6ff"/>
   </g>
-  <!-- O2 label overlay -->
-  <text x="16" y="28" text-anchor="middle" dominant-baseline="middle"
-        font-family="Arial" font-weight="bold" font-size="14"
-        fill="#ffffff" stroke="#000000" stroke-width="2" paint-order="stroke">O₂</text>
+  <!-- O2 label above valve -->
+  <text x="16" y="9" text-anchor="middle" dominant-baseline="middle"
+        font-family="Arial" font-weight="bold" font-size="6"
+        fill="#ffffff" stroke="#000000" stroke-width="0.75" paint-order="stroke">O2</text>
 </svg>

--- a/assets/images/air_tank.svg
+++ b/assets/images/air_tank.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="128" viewBox="0 0 64 128">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <defs>
     <linearGradient id="tankBody" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#c6ecff"/>
@@ -9,35 +9,33 @@
       <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
     </radialGradient>
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#000000" flood-opacity="0.5"/>
+      <feDropShadow dx="0" dy="1" stdDeviation="1" flood-color="#000000" flood-opacity="0.5"/>
     </filter>
   </defs>
   <!-- Tank body -->
   <g filter="url(#shadow)">
-    <rect x="12" y="20" width="40" height="88" rx="12" fill="url(#tankBody)" stroke="#2b6f95" stroke-width="2"/>
-    <!-- highlight -->
-    <rect x="12" y="20" width="40" height="88" rx="12" fill="url(#tankHighlight)"/>
+    <rect x="9" y="8" width="14" height="18" rx="4" fill="url(#tankBody)" stroke="#2b6f95" stroke-width="1.5"/>
+    <rect x="9" y="8" width="14" height="18" rx="4" fill="url(#tankHighlight)"/>
   </g>
   <!-- Valve -->
   <g filter="url(#shadow)">
-    <rect x="26" y="10" width="12" height="12" rx="2" fill="#4dd0e1" stroke="#2b6f95" stroke-width="2"/>
-    <circle cx="32" cy="16" r="4" fill="#ffffff" stroke="#2b6f95" stroke-width="2"/>
-    <line x1="32" y1="16" x2="32" y2="12" stroke="#2b6f95" stroke-width="2"/>
-    <line x1="32" y1="16" x2="36" y2="16" stroke="#2b6f95" stroke-width="2"/>
+    <rect x="13" y="4" width="6" height="4" rx="1" fill="#4dd0e1" stroke="#2b6f95" stroke-width="1.5"/>
+    <circle cx="16" cy="6" r="2" fill="#ffffff" stroke="#2b6f95" stroke-width="1.5"/>
+    <line x1="16" y1="6" x2="16" y2="4" stroke="#2b6f95" stroke-width="1.5"/>
+    <line x1="16" y1="6" x2="18" y2="6" stroke="#2b6f95" stroke-width="1.5"/>
   </g>
   <!-- Gauge -->
   <g filter="url(#shadow)">
-    <circle cx="32" cy="50" r="10" fill="#ffffff" stroke="#2b6f95" stroke-width="2"/>
-    <line x1="32" y1="50" x2="38" y2="46" stroke="#2b6f95" stroke-width="2"/>
+    <circle cx="16" cy="18" r="4" fill="#ffffff" stroke="#2b6f95" stroke-width="1.5"/>
+    <line x1="16" y1="18" x2="19" y2="17" stroke="#2b6f95" stroke-width="1.5"/>
   </g>
   <!-- Decorative stripes -->
   <g>
-    <rect x="12" y="50" width="40" height="8" fill="#81c6ff"/>
-    <rect x="12" y="72" width="40" height="8" fill="#81c6ff"/>
+    <rect x="9" y="18" width="14" height="2" fill="#81c6ff"/>
+    <rect x="9" y="22" width="14" height="2" fill="#81c6ff"/>
   </g>
   <!-- O2 label overlay -->
-  <text x="32" y="64" text-anchor="middle" dominant-baseline="middle"
-        textLength="64" lengthAdjust="spacingAndGlyphs"
-        font-family="Arial" font-weight="bold" font-size="60"
-        fill="#ffffff" stroke="#000000" stroke-width="4" paint-order="stroke">O₂</text>
+  <text x="16" y="28" text-anchor="middle" dominant-baseline="middle"
+        font-family="Arial" font-weight="bold" font-size="14"
+        fill="#ffffff" stroke="#000000" stroke-width="2" paint-order="stroke">O₂</text>
 </svg>

--- a/assets/images/air_tank.svg
+++ b/assets/images/air_tank.svg
@@ -34,8 +34,8 @@
     <rect x="5" y="18" width="22" height="2" fill="#81c6ff"/>
     <rect x="5" y="22" width="22" height="2" fill="#81c6ff"/>
   </g>
-  <!-- O2 label above valve -->
-  <text x="16" y="9" text-anchor="middle" dominant-baseline="middle"
-        font-family="Arial" font-weight="bold" font-size="6"
-        fill="#ffffff" stroke="#000000" stroke-width="0.75" paint-order="stroke">O2</text>
+  <!-- Central O₂ label overlay -->
+  <text x="16" y="16" text-anchor="middle" dominant-baseline="middle"
+        font-family="Arial" font-weight="bold" font-size="20"
+        fill="#ffffff" stroke="#000000" stroke-width="1" paint-order="stroke">O₂</text>
 </svg>

--- a/assets/images/air_tank.svg
+++ b/assets/images/air_tank.svg
@@ -35,4 +35,9 @@
     <rect x="12" y="50" width="40" height="8" fill="#81c6ff"/>
     <rect x="12" y="72" width="40" height="8" fill="#81c6ff"/>
   </g>
+  <!-- O2 label overlay -->
+  <text x="32" y="64" text-anchor="middle" dominant-baseline="middle"
+        textLength="64" lengthAdjust="spacingAndGlyphs"
+        font-family="Arial" font-weight="bold" font-size="60"
+        fill="#ffffff" stroke="#000000" stroke-width="4" paint-order="stroke">O₂</text>
 </svg>

--- a/characters.js
+++ b/characters.js
@@ -26,7 +26,9 @@ async function loadAll() {
       img.onload = resolve;
       img.onerror = resolve;
     });
-    img.src = 'data:image/svg+xml;base64,' + btoa(svgText);
+    // btoa only supports Latin1; handle UTF-8 characters like O₂
+    const encoded = btoa(unescape(encodeURIComponent(svgText)));
+    img.src = 'data:image/svg+xml;base64,' + encoded;
     await loaded;
     const canvas = document.createElement('canvas');
     canvas.width = img.width;


### PR DESCRIPTION
## Summary
- switch overlay text to the chemical symbol O₂
- make the black outline of the label thicker for better visibility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882e152ad5c83338850145a8f75dd23