### PR TITLE
Implement game over sequence

### DIFF
--- a/game-state.js
+++ b/game-state.js
@@ -1,4 +1,4 @@
-export default class GameState {
+export class GameState {
   constructor() {
     // Number of maze chunks the player has cleared
     this.clearedMazes = 0;
@@ -14,3 +14,6 @@ export default class GameState {
     this.clearedMazes = 0;
   }
 }
+
+const gameState = new GameState();
+export default gameState;

--- a/game.js
+++ b/game.js
@@ -128,7 +128,7 @@ class GameScene extends Phaser.Scene {
   update() {
     const delta = this.game.loop.delta;
 
-    if (!this.isMoving) {
+    if (!this.isMoving && !this.isGameOver) {
       const entry = this.inputBuffer.consume();
       if (entry) {
         const size = this.mazeManager.tileSize;
@@ -342,6 +342,14 @@ class GameScene extends Phaser.Scene {
       this.bgm.stop();
     }
     this.sound.stopAll();
+    this.sound.play('game_over');
+
+    this.tweens.killTweensOf(this.heroSprite);
+    if (this.heroAnimationTimer) {
+      this.heroAnimationTimer.remove();
+      this.heroAnimationTimer = null;
+    }
+    this.isMoving = false;
 
     const size = this.mazeManager.tileSize;
     const evaporate = () => {
@@ -351,7 +359,7 @@ class GameScene extends Phaser.Scene {
         this.heroSprite.y - size,
         size,
         size * 2,
-        0xffffff
+        0x000000
       );
     };
     evaporate();
@@ -361,17 +369,14 @@ class GameScene extends Phaser.Scene {
       callback: evaporate
     });
 
-    this.tweens.add({
-      targets: this.heroSprite,
-      alpha: 0,
-      duration: 2000,
-      onComplete: () => {
-        evapTimer.remove();
-        this.heroSprite.destroy();
-        this.scene.launch('GameOverScene');
-        this.scene.bringToTop('GameOverScene');
-        this.scene.pause();
-      }
+    this.heroSprite.setVisible(false);
+
+    this.time.delayedCall(2000, () => {
+      evapTimer.remove();
+      this.heroSprite.destroy();
+      this.scene.launch('GameOverScene');
+      this.scene.bringToTop('GameOverScene');
+      this.scene.pause();
     });
   }
 

--- a/game.js
+++ b/game.js
@@ -1,4 +1,4 @@
-import GameState from './game-state.js';
+import gameState from './game-state.js';
 import HeroState from './hero_state.js';
 import CameraManager from './camera.js';
 import MazeManager from './maze_manager.js';
@@ -17,7 +17,6 @@ const VIRTUAL_WIDTH = 480;
 const VIRTUAL_HEIGHT = 270;
 
 // Global state for tracking overall game progress
-const gameState = new GameState();
 
 class GameScene extends Phaser.Scene {
   constructor() {

--- a/game_over_scene.js
+++ b/game_over_scene.js
@@ -1,0 +1,66 @@
+const VIRTUAL_WIDTH = 480;
+const VIRTUAL_HEIGHT = 270;
+import gameState from './game-state.js';
+
+export default class GameOverScene extends Phaser.Scene {
+  constructor() {
+    super('GameOverScene');
+  }
+
+  create() {
+    const { width, height } = this.scale.gameSize;
+    this.cameras.main.setViewport(
+      (width - VIRTUAL_WIDTH * 2) / 2,
+      (height - VIRTUAL_HEIGHT * 2) / 2,
+      VIRTUAL_WIDTH * 2,
+      VIRTUAL_HEIGHT * 2
+    );
+
+    this.mask = this.add.rectangle(0, 0, VIRTUAL_WIDTH * 2, VIRTUAL_HEIGHT * 2, 0x000000)
+      .setOrigin(0)
+      .setAlpha(0);
+    this.tweens.add({ targets: this.mask, alpha: 0.6, duration: 500 });
+
+    this.letters = this.createFloatingText('RETRY?', VIRTUAL_WIDTH, VIRTUAL_HEIGHT);
+
+    this.input.keyboard.once('keydown-W', () => this.restartGame());
+    this.input.keyboard.once('keydown-A', () => this.restartGame());
+    this.input.keyboard.once('keydown-S', () => this.restartGame());
+    this.input.keyboard.once('keydown-D', () => this.restartGame());
+  }
+
+  createFloatingText(str, centerX, y) {
+    const style = { fontFamily: 'monospace', fontSize: '48px', color: '#ffffff' };
+    const measure = this.add.text(0, 0, str, style).setOrigin(0.5);
+    const total = measure.width;
+    measure.destroy();
+    let x = centerX - total / 2;
+    const letters = [];
+    for (const ch of str) {
+      const letter = this.add.text(0, 0, ch, style).setOrigin(0.5);
+      letter.x = x + letter.width / 2;
+      letter.y = y;
+      letter.setDepth(1001);
+      this.tweens.add({
+        targets: letter,
+        y: letter.y + Phaser.Math.Between(-6, 6),
+        duration: 800 + Phaser.Math.Between(0, 400),
+        repeat: -1,
+        yoyo: true,
+        ease: 'Sine.easeInOut',
+        delay: Phaser.Math.Between(0, 300)
+      });
+      letters.push(letter);
+      x += letter.width;
+    }
+    return letters;
+  }
+
+  restartGame() {
+    this.scene.stop('GameScene');
+    this.scene.stop('UIScene');
+    gameState.reset();
+    this.scene.start('GameScene');
+    this.scene.stop();
+  }
+}

--- a/maze_manager.js
+++ b/maze_manager.js
@@ -153,8 +153,7 @@ export default class MazeManager {
       obj.age += delta;
       if (heroIdx >= obj.index + 2 && !obj.fading) {
         if (this.isHeroInside(hero, obj)) {
-          this.scene.sound.play('game_over');
-          this.scene.scene.restart();
+          this.scene.handleGameOver();
         }
         const size = obj.chunk.size * this.tileSize;
         evaporateChunk(this.scene, obj.offsetX, obj.offsetY, size, size);
@@ -170,8 +169,7 @@ export default class MazeManager {
           duration: this.fadeDuration,
           onComplete: () => {
             if (this.isHeroInside(hero, obj)) {
-              this.scene.sound.play('game_over');
-              this.scene.scene.restart();
+              this.scene.handleGameOver();
             }
             const size = obj.chunk.size * this.tileSize;
             evaporateChunk(this.scene, obj.offsetX, obj.offsetY, size, size);

--- a/ui_scene.js
+++ b/ui_scene.js
@@ -22,6 +22,13 @@ export default class UIScene extends Phaser.Scene {
     gameScene.events.on('updateChunks', this.updateChunks, this);
     gameScene.events.on('updateOxygen', this.updateOxygen, this);
 
+    this.shutdownHandler = () => {
+      this.scale.off('resize', this.resizeHandler);
+      gameScene.events.off('updateChunks', this.updateChunks, this);
+      gameScene.events.off('updateOxygen', this.updateOxygen, this);
+    };
+    this.events.once('shutdown', this.shutdownHandler);
+
     this.oxygenGfx = this.add.graphics();
     this.o2Label = this.add.text(0, 0, 'O2 Timer', {
       fontFamily: 'monospace',
@@ -38,9 +45,11 @@ export default class UIScene extends Phaser.Scene {
       color: '#ffffff'
     }).setVisible(false);
 
-    this.scale.on('resize', (gw, gh) => {
+    this.resizeHandler = (gw, gh) => {
+      if (!this.cameras || !this.cameras.main) return;
       this.cameras.main.setViewport((gw - VIRTUAL_WIDTH * 2) / 2, (gh - VIRTUAL_HEIGHT * 2) / 2, VIRTUAL_WIDTH * 2, VIRTUAL_HEIGHT * 2);
-    });
+    };
+    this.scale.on('resize', this.resizeHandler);
   }
 
   update() {
@@ -50,7 +59,7 @@ export default class UIScene extends Phaser.Scene {
   }
 
   updateChunks(count) {
-    // Right pad with spaces to keep label position stable
+    if (!this.chunkText || !this.chunkText.setText) return;
     this.chunkText.setText('CHUNK ' + count.toString());
   }
 


### PR DESCRIPTION
## Summary
- add new `GameOverScene` to display Retry prompt
- fade out the hero with particle effect and stop BGM
- trigger `GameOverScene` from oxygen depletion or chunk removal
- restart game when pressing WASD

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6882e05106d48333b9a6d7301766e96a