### PR TITLE
Add directional frog sprites

### DIFF
--- a/assets/images/hero_back_walk1.svg
+++ b/assets/images/hero_back_walk1.svg
@@ -4,9 +4,11 @@
       <stop offset="0%" stop-color="#aee868"/>
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
+    <linearGradient id="tankGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#b0e0ff"/>
+      <stop offset="100%" stop-color="#3399ff"/>
+    </linearGradient>
   </defs>
-  <!-- Oxygen Tank -->
-  <rect x="12" y="16" width="8" height="12" rx="2" fill="#6fa8dc" stroke="#2b6f95" stroke-width="1"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Suit Torso -->
@@ -19,6 +21,13 @@
   <!-- Legs -->
   <ellipse cx="11" cy="34" rx="4" ry="2" fill="#8cc84b"/>
   <ellipse cx="21" cy="34" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Oxygen Tank -->
+  <g id="tank">
+    <rect x="11" y="15" width="10" height="15" rx="3" fill="url(#tankGrad)" stroke="#2b6f95" stroke-width="1.5"/>
+    <rect x="11" y="22" width="10" height="2" fill="#333" opacity="0.4"/>
+    <line x1="16" y1="15" x2="16" y2="12" stroke="#c0c0c0" stroke-width="2"/>
+    <circle cx="16" cy="11" r="2" fill="#99d9ff" stroke="#2b6f95" stroke-width="0.5"/>
+  </g>
   <!-- Head -->
   <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <ellipse cx="8" cy="14" rx="4" ry="2" fill="#8cc84b"/>

--- a/assets/images/hero_back_walk1.svg
+++ b/assets/images/hero_back_walk1.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#aee868"/>
+      <stop offset="100%" stop-color="#6aa84f"/>
+    </linearGradient>
+  </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <!-- Suit Torso -->
+  <rect x="10" y="18" width="12" height="14" rx="3" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <!-- Suit Arms -->
+  <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <!-- Suit Belt -->
+  <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <!-- Legs -->
+  <ellipse cx="11" cy="34" rx="4" ry="2" fill="#8cc84b"/>
+  <ellipse cx="21" cy="34" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <ellipse cx="8" cy="14" rx="4" ry="2" fill="#8cc84b"/>
+  <ellipse cx="24" cy="14" rx="4" ry="2" fill="#8cc84b"/>
+  <path d="M10 12 L22 12" stroke="#4e7c3a" stroke-width="2"/>
+              <!-- Helmet -->
+  <circle cx="16" cy="12" r="12" fill="#e0f7ff" fill-opacity="0.5" stroke="#99ccff" stroke-width="2"/>
+</svg>

--- a/assets/images/hero_back_walk1.svg
+++ b/assets/images/hero_back_walk1.svg
@@ -5,6 +5,8 @@
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
   </defs>
+  <!-- Oxygen Tank -->
+  <rect x="12" y="16" width="8" height="12" rx="2" fill="#6fa8dc" stroke="#2b6f95" stroke-width="1"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Suit Torso -->

--- a/assets/images/hero_back_walk2.svg
+++ b/assets/images/hero_back_walk2.svg
@@ -4,9 +4,11 @@
       <stop offset="0%" stop-color="#aee868"/>
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
+    <linearGradient id="tankGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#b0e0ff"/>
+      <stop offset="100%" stop-color="#3399ff"/>
+    </linearGradient>
   </defs>
-  <!-- Oxygen Tank -->
-  <rect x="12" y="16" width="8" height="12" rx="2" fill="#6fa8dc" stroke="#2b6f95" stroke-width="1"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Suit Torso -->
@@ -19,6 +21,13 @@
   <!-- Legs -->
   <ellipse cx="11" cy="32" rx="4" ry="2" fill="#8cc84b"/>
   <ellipse cx="21" cy="36" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Oxygen Tank -->
+  <g id="tank">
+    <rect x="11" y="15" width="10" height="15" rx="3" fill="url(#tankGrad)" stroke="#2b6f95" stroke-width="1.5"/>
+    <rect x="11" y="22" width="10" height="2" fill="#333" opacity="0.4"/>
+    <line x1="16" y1="15" x2="16" y2="12" stroke="#c0c0c0" stroke-width="2"/>
+    <circle cx="16" cy="11" r="2" fill="#99d9ff" stroke="#2b6f95" stroke-width="0.5"/>
+  </g>
   <!-- Head -->
   <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <ellipse cx="8" cy="13" rx="4" ry="2" fill="#8cc84b"/>

--- a/assets/images/hero_back_walk2.svg
+++ b/assets/images/hero_back_walk2.svg
@@ -5,6 +5,8 @@
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
   </defs>
+  <!-- Oxygen Tank -->
+  <rect x="12" y="16" width="8" height="12" rx="2" fill="#6fa8dc" stroke="#2b6f95" stroke-width="1"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Suit Torso -->

--- a/assets/images/hero_back_walk2.svg
+++ b/assets/images/hero_back_walk2.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#aee868"/>
+      <stop offset="100%" stop-color="#6aa84f"/>
+    </linearGradient>
+  </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <!-- Suit Torso -->
+  <rect x="10" y="18" width="12" height="14" rx="3" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <!-- Suit Arms -->
+  <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <!-- Suit Belt -->
+  <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <!-- Legs -->
+  <ellipse cx="11" cy="32" rx="4" ry="2" fill="#8cc84b"/>
+  <ellipse cx="21" cy="36" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <ellipse cx="8" cy="13" rx="4" ry="2" fill="#8cc84b"/>
+  <ellipse cx="24" cy="15" rx="4" ry="2" fill="#8cc84b"/>
+  <path d="M10 12 L22 12" stroke="#4e7c3a" stroke-width="2"/>
+              <!-- Helmet -->
+  <circle cx="16" cy="12" r="12" fill="#e0f7ff" fill-opacity="0.5" stroke="#99ccff" stroke-width="2"/>
+</svg>

--- a/assets/images/hero_back_walk3.svg
+++ b/assets/images/hero_back_walk3.svg
@@ -4,9 +4,11 @@
       <stop offset="0%" stop-color="#aee868"/>
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
+    <linearGradient id="tankGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#b0e0ff"/>
+      <stop offset="100%" stop-color="#3399ff"/>
+    </linearGradient>
   </defs>
-  <!-- Oxygen Tank -->
-  <rect x="12" y="16" width="8" height="12" rx="2" fill="#6fa8dc" stroke="#2b6f95" stroke-width="1"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Suit Torso -->
@@ -19,6 +21,13 @@
   <!-- Legs -->
   <ellipse cx="11" cy="36" rx="4" ry="2" fill="#8cc84b"/>
   <ellipse cx="21" cy="32" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Oxygen Tank -->
+  <g id="tank">
+    <rect x="11" y="15" width="10" height="15" rx="3" fill="url(#tankGrad)" stroke="#2b6f95" stroke-width="1.5"/>
+    <rect x="11" y="22" width="10" height="2" fill="#333" opacity="0.4"/>
+    <line x1="16" y1="15" x2="16" y2="12" stroke="#c0c0c0" stroke-width="2"/>
+    <circle cx="16" cy="11" r="2" fill="#99d9ff" stroke="#2b6f95" stroke-width="0.5"/>
+  </g>
   <!-- Head -->
   <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <ellipse cx="8" cy="15" rx="4" ry="2" fill="#8cc84b"/>

--- a/assets/images/hero_back_walk3.svg
+++ b/assets/images/hero_back_walk3.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#aee868"/>
+      <stop offset="100%" stop-color="#6aa84f"/>
+    </linearGradient>
+  </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <!-- Suit Torso -->
+  <rect x="10" y="18" width="12" height="14" rx="3" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <!-- Suit Arms -->
+  <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <!-- Suit Belt -->
+  <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <!-- Legs -->
+  <ellipse cx="11" cy="36" rx="4" ry="2" fill="#8cc84b"/>
+  <ellipse cx="21" cy="32" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <ellipse cx="8" cy="15" rx="4" ry="2" fill="#8cc84b"/>
+  <ellipse cx="24" cy="13" rx="4" ry="2" fill="#8cc84b"/>
+  <path d="M10 12 L22 12" stroke="#4e7c3a" stroke-width="2"/>
+              <!-- Helmet -->
+  <circle cx="16" cy="12" r="12" fill="#e0f7ff" fill-opacity="0.5" stroke="#99ccff" stroke-width="2"/>
+</svg>

--- a/assets/images/hero_back_walk3.svg
+++ b/assets/images/hero_back_walk3.svg
@@ -5,6 +5,8 @@
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
   </defs>
+  <!-- Oxygen Tank -->
+  <rect x="12" y="16" width="8" height="12" rx="2" fill="#6fa8dc" stroke="#2b6f95" stroke-width="1"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Suit Torso -->

--- a/assets/images/hero_right_walk1.svg
+++ b/assets/images/hero_right_walk1.svg
@@ -4,9 +4,11 @@
       <stop offset="0%" stop-color="#aee868"/>
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
+    <linearGradient id="tankGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#b0e0ff"/>
+      <stop offset="100%" stop-color="#3399ff"/>
+    </linearGradient>
   </defs>
-  <!-- Oxygen Tank -->
-  <rect x="10" y="16" width="6" height="12" rx="2" fill="#6fa8dc" stroke="#2b6f95" stroke-width="1"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Suit Torso -->
@@ -18,6 +20,13 @@
   <!-- Legs -->
   <ellipse cx="11" cy="34" rx="4" ry="2" fill="#8cc84b"/>
   <ellipse cx="21" cy="34" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Oxygen Tank -->
+  <g id="tank">
+    <rect x="9" y="15" width="10" height="15" rx="3" fill="url(#tankGrad)" stroke="#2b6f95" stroke-width="1.5"/>
+    <rect x="9" y="22" width="10" height="2" fill="#333" opacity="0.4"/>
+    <line x1="14" y1="15" x2="14" y2="12" stroke="#c0c0c0" stroke-width="2"/>
+    <circle cx="14" cy="11" r="2" fill="#99d9ff" stroke="#2b6f95" stroke-width="0.5"/>
+  </g>
   <!-- Head -->
   <ellipse cx="18" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <ellipse cx="24" cy="14" rx="4" ry="2" fill="#8cc84b"/>

--- a/assets/images/hero_right_walk1.svg
+++ b/assets/images/hero_right_walk1.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#aee868"/>
+      <stop offset="100%" stop-color="#6aa84f"/>
+    </linearGradient>
+  </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <!-- Suit Torso -->
+  <rect x="10" y="18" width="12" height="14" rx="3" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <!-- Suit Arms -->
+  <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <!-- Suit Belt -->
+  <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <!-- Legs -->
+  <ellipse cx="11" cy="34" rx="4" ry="2" fill="#8cc84b"/>
+  <ellipse cx="21" cy="34" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Head -->
+  <ellipse cx="18" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <ellipse cx="24" cy="14" rx="4" ry="2" fill="#8cc84b"/>
+  <circle cx="22" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="22" cy="6" r="2" fill="#000000"/>
+  <path d="M14 12 Q18 16 22 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M10 11 C12 9, 24 9, 26 11" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Helmet -->
+  <circle cx="18" cy="12" r="12" fill="#e0f7ff" fill-opacity="0.5" stroke="#99ccff" stroke-width="2"/>
+</svg>

--- a/assets/images/hero_right_walk1.svg
+++ b/assets/images/hero_right_walk1.svg
@@ -5,6 +5,8 @@
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
   </defs>
+  <!-- Oxygen Tank -->
+  <rect x="10" y="16" width="6" height="12" rx="2" fill="#6fa8dc" stroke="#2b6f95" stroke-width="1"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Suit Torso -->

--- a/assets/images/hero_right_walk1.svg
+++ b/assets/images/hero_right_walk1.svg
@@ -10,8 +10,7 @@
   <!-- Suit Torso -->
   <rect x="10" y="18" width="12" height="14" rx="3" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
   <!-- Suit Arms -->
-  <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
-  <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <rect x="16" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
   <!-- Suit Belt -->
   <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
   <!-- Legs -->

--- a/assets/images/hero_right_walk2.svg
+++ b/assets/images/hero_right_walk2.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#aee868"/>
+      <stop offset="100%" stop-color="#6aa84f"/>
+    </linearGradient>
+  </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <!-- Suit Torso -->
+  <rect x="10" y="18" width="12" height="14" rx="3" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <!-- Suit Arms -->
+  <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <!-- Suit Belt -->
+  <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <!-- Legs -->
+  <ellipse cx="11" cy="32" rx="4" ry="2" fill="#8cc84b"/>
+  <ellipse cx="21" cy="36" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Head -->
+  <ellipse cx="18" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <ellipse cx="24" cy="15" rx="4" ry="2" fill="#8cc84b"/>
+  <circle cx="22" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="22" cy="6" r="2" fill="#000000"/>
+  <path d="M14 12 Q18 16 22 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M10 11 C12 9, 24 9, 26 11" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Helmet -->
+  <circle cx="18" cy="12" r="12" fill="#e0f7ff" fill-opacity="0.5" stroke="#99ccff" stroke-width="2"/>
+</svg>

--- a/assets/images/hero_right_walk2.svg
+++ b/assets/images/hero_right_walk2.svg
@@ -5,6 +5,8 @@
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
   </defs>
+  <!-- Oxygen Tank -->
+  <rect x="10" y="16" width="6" height="12" rx="2" fill="#6fa8dc" stroke="#2b6f95" stroke-width="1"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Suit Torso -->

--- a/assets/images/hero_right_walk2.svg
+++ b/assets/images/hero_right_walk2.svg
@@ -4,9 +4,11 @@
       <stop offset="0%" stop-color="#aee868"/>
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
+    <linearGradient id="tankGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#b0e0ff"/>
+      <stop offset="100%" stop-color="#3399ff"/>
+    </linearGradient>
   </defs>
-  <!-- Oxygen Tank -->
-  <rect x="10" y="16" width="6" height="12" rx="2" fill="#6fa8dc" stroke="#2b6f95" stroke-width="1"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Suit Torso -->
@@ -18,6 +20,13 @@
   <!-- Legs -->
   <ellipse cx="11" cy="32" rx="4" ry="2" fill="#8cc84b"/>
   <ellipse cx="21" cy="36" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Oxygen Tank -->
+  <g id="tank">
+    <rect x="9" y="15" width="10" height="15" rx="3" fill="url(#tankGrad)" stroke="#2b6f95" stroke-width="1.5"/>
+    <rect x="9" y="22" width="10" height="2" fill="#333" opacity="0.4"/>
+    <line x1="14" y1="15" x2="14" y2="12" stroke="#c0c0c0" stroke-width="2"/>
+    <circle cx="14" cy="11" r="2" fill="#99d9ff" stroke="#2b6f95" stroke-width="0.5"/>
+  </g>
   <!-- Head -->
   <ellipse cx="18" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <ellipse cx="24" cy="15" rx="4" ry="2" fill="#8cc84b"/>

--- a/assets/images/hero_right_walk2.svg
+++ b/assets/images/hero_right_walk2.svg
@@ -10,8 +10,7 @@
   <!-- Suit Torso -->
   <rect x="10" y="18" width="12" height="14" rx="3" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
   <!-- Suit Arms -->
-  <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
-  <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <rect x="16" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
   <!-- Suit Belt -->
   <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
   <!-- Legs -->

--- a/assets/images/hero_right_walk3.svg
+++ b/assets/images/hero_right_walk3.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#aee868"/>
+      <stop offset="100%" stop-color="#6aa84f"/>
+    </linearGradient>
+  </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <!-- Suit Torso -->
+  <rect x="10" y="18" width="12" height="14" rx="3" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <!-- Suit Arms -->
+  <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <!-- Suit Belt -->
+  <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <!-- Legs -->
+  <ellipse cx="11" cy="36" rx="4" ry="2" fill="#8cc84b"/>
+  <ellipse cx="21" cy="32" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Head -->
+  <ellipse cx="18" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <ellipse cx="24" cy="13" rx="4" ry="2" fill="#8cc84b"/>
+  <circle cx="22" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="22" cy="6" r="2" fill="#000000"/>
+  <path d="M14 12 Q18 16 22 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M10 11 C12 9, 24 9, 26 11" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Helmet -->
+  <circle cx="18" cy="12" r="12" fill="#e0f7ff" fill-opacity="0.5" stroke="#99ccff" stroke-width="2"/>
+</svg>

--- a/assets/images/hero_right_walk3.svg
+++ b/assets/images/hero_right_walk3.svg
@@ -4,9 +4,11 @@
       <stop offset="0%" stop-color="#aee868"/>
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
+    <linearGradient id="tankGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#b0e0ff"/>
+      <stop offset="100%" stop-color="#3399ff"/>
+    </linearGradient>
   </defs>
-  <!-- Oxygen Tank -->
-  <rect x="10" y="16" width="6" height="12" rx="2" fill="#6fa8dc" stroke="#2b6f95" stroke-width="1"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Suit Torso -->
@@ -18,6 +20,13 @@
   <!-- Legs -->
   <ellipse cx="11" cy="36" rx="4" ry="2" fill="#8cc84b"/>
   <ellipse cx="21" cy="32" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Oxygen Tank -->
+  <g id="tank">
+    <rect x="9" y="15" width="10" height="15" rx="3" fill="url(#tankGrad)" stroke="#2b6f95" stroke-width="1.5"/>
+    <rect x="9" y="22" width="10" height="2" fill="#333" opacity="0.4"/>
+    <line x1="14" y1="15" x2="14" y2="12" stroke="#c0c0c0" stroke-width="2"/>
+    <circle cx="14" cy="11" r="2" fill="#99d9ff" stroke="#2b6f95" stroke-width="0.5"/>
+  </g>
   <!-- Head -->
   <ellipse cx="18" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <ellipse cx="24" cy="13" rx="4" ry="2" fill="#8cc84b"/>

--- a/assets/images/hero_right_walk3.svg
+++ b/assets/images/hero_right_walk3.svg
@@ -5,6 +5,8 @@
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
   </defs>
+  <!-- Oxygen Tank -->
+  <rect x="10" y="16" width="6" height="12" rx="2" fill="#6fa8dc" stroke="#2b6f95" stroke-width="1"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Suit Torso -->

--- a/assets/images/hero_right_walk3.svg
+++ b/assets/images/hero_right_walk3.svg
@@ -10,8 +10,7 @@
   <!-- Suit Torso -->
   <rect x="10" y="18" width="12" height="14" rx="3" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
   <!-- Suit Arms -->
-  <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
-  <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <rect x="16" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
   <!-- Suit Belt -->
   <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
   <!-- Legs -->

--- a/characters.js
+++ b/characters.js
@@ -11,6 +11,12 @@ const SPRITES = {
   hero_walk1: 'hero_walk1.svg',
   hero_walk2: 'hero_walk2.svg',
   hero_walk3: 'hero_walk3.svg',
+  hero_back_walk1: 'hero_back_walk1.svg',
+  hero_back_walk2: 'hero_back_walk2.svg',
+  hero_back_walk3: 'hero_back_walk3.svg',
+  hero_right_walk1: 'hero_right_walk1.svg',
+  hero_right_walk2: 'hero_right_walk2.svg',
+  hero_right_walk3: 'hero_right_walk3.svg',
   arrow: 'arrow.svg',
   key: 'key.svg',
   air_tank: 'air_tank.svg'

--- a/game.js
+++ b/game.js
@@ -173,7 +173,16 @@ class GameScene extends Phaser.Scene {
           const duration = (size / pixelsPerSecond) * 1000;
           this.sound.play('hero_walk');
 
-          const frames = ['hero_walk1', 'hero_walk2', 'hero_walk3'];
+          let orientation = moveDir;
+          if (moveDir === 'left') orientation = 'right';
+          this.hero.direction = orientation;
+          const frameMap = {
+            down: ['hero_walk1', 'hero_walk2', 'hero_walk3'],
+            up: ['hero_back_walk1', 'hero_back_walk2', 'hero_back_walk3'],
+            right: ['hero_right_walk1', 'hero_right_walk2', 'hero_right_walk3']
+          };
+          const frames = frameMap[orientation];
+          this.heroImage.setFlipX(moveDir === 'left');
           this.heroAnimIndex = 0;
           this.heroImage.setTexture(frames[0]);
           this.heroAnimationTimer = this.time.addEvent({
@@ -196,7 +205,7 @@ class GameScene extends Phaser.Scene {
                 this.heroAnimationTimer.remove();
                 this.heroAnimationTimer = null;
               }
-              this.heroImage.setTexture('hero_idle');
+              this.heroImage.setTexture(frames[0]);
               this.inputBuffer.repeat(moveDir);
             }
           });

--- a/hero_state.js
+++ b/hero_state.js
@@ -10,6 +10,7 @@ export default class HeroState {
     this.keys = 0;
     this.maxOxygen = 20;
     this.oxygen = 20;
+    this.direction = 'down';
   }
 
   moveTo(x, y) {


### PR DESCRIPTION
## Summary
- create back-facing and right-facing SVGs for frog hero
- load new sprite assets
- track hero facing direction
- switch animation frames based on movement direction

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882f4d01b0083338e2a0dd7d510c9bd