### PR TITLE
Add automatic gate SVGs

### DIFF
--- a/assets/images/auto_gate_closed.svg
+++ b/assets/images/auto_gate_closed.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <defs>
+    <linearGradient id="gateSilver" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#cccccc"/>
+      <stop offset="100%" stop-color="#888888"/>
+    </linearGradient>
+    <linearGradient id="frameSilver" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#eeeeee"/>
+      <stop offset="100%" stop-color="#aaaaaa"/>
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="28" height="28" fill="url(#frameSilver)" stroke="#bbbbbb" stroke-width="2"/>
+  <rect x="6" y="4" width="10" height="24" fill="url(#gateSilver)" stroke="#666666" stroke-width="1"/>
+  <rect x="16" y="4" width="10" height="24" fill="url(#gateSilver)" stroke="#666666" stroke-width="1"/>
+  <line x1="16" y1="4" x2="16" y2="28" stroke="#999999" stroke-width="1"/>
+  <line x1="6" y1="10" x2="26" y2="10" stroke="#bbbbbb" stroke-width="0.8"/>
+  <line x1="6" y1="16" x2="26" y2="16" stroke="#bbbbbb" stroke-width="0.8"/>
+  <line x1="6" y1="22" x2="26" y2="22" stroke="#bbbbbb" stroke-width="0.8"/>
+  <circle cx="16" cy="8" r="2" fill="#ff3333" stroke="#660000" stroke-width="0.5"/>
+</svg>

--- a/assets/images/auto_gate_open.svg
+++ b/assets/images/auto_gate_open.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <defs>
+    <linearGradient id="gateSilverOpen" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#cccccc"/>
+      <stop offset="100%" stop-color="#888888"/>
+    </linearGradient>
+    <linearGradient id="frameSilverOpen" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#eeeeee"/>
+      <stop offset="100%" stop-color="#aaaaaa"/>
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="28" height="28" fill="none" stroke="#bbbbbb" stroke-width="2"/>
+  <rect x="2" y="4" width="8" height="24" fill="url(#gateSilverOpen)" stroke="#666666" stroke-width="1"/>
+  <rect x="22" y="4" width="8" height="24" fill="url(#gateSilverOpen)" stroke="#666666" stroke-width="1"/>
+  <line x1="2" y1="10" x2="10" y2="10" stroke="#bbbbbb" stroke-width="0.8"/>
+  <line x1="2" y1="16" x2="10" y2="16" stroke="#bbbbbb" stroke-width="0.8"/>
+  <line x1="2" y1="22" x2="10" y2="22" stroke="#bbbbbb" stroke-width="0.8"/>
+  <line x1="22" y1="10" x2="30" y2="10" stroke="#bbbbbb" stroke-width="0.8"/>
+  <line x1="22" y1="16" x2="30" y2="16" stroke="#bbbbbb" stroke-width="0.8"/>
+  <line x1="22" y1="22" x2="30" y2="22" stroke="#bbbbbb" stroke-width="0.8"/>
+  <circle cx="8" cy="8" r="2" fill="#00ff33" stroke="#006600" stroke-width="0.5"/>
+  <circle cx="24" cy="8" r="2" fill="#00ff33" stroke="#006600" stroke-width="0.5"/>
+</svg>


### PR DESCRIPTION
## Summary
- add `auto_gate_closed.svg` for red-lit closed gate
- add `auto_gate_open.svg` for green-lit open gate

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688335c99ff08333a3ea0d3201734bc1