### PR TITLE
Offset key display position

### DIFF
--- a/game.js
+++ b/game.js
@@ -75,7 +75,10 @@ class GameScene extends Phaser.Scene {
     this.worldLayer.add(this.heroSprite);
 
     // Persistent key display above the hero
-    this.keyDisplay = this.add.container(this.heroSprite.x - 10, this.heroSprite.y - this.mazeManager.tileSize);
+    this.keyDisplay = this.add.container(
+      this.heroSprite.x - 10,
+      this.heroSprite.y - this.mazeManager.tileSize + 5
+    );
     this.keyIcon = Characters.createKey(this);
     this.keyIcon.setDisplaySize(this.mazeManager.tileSize, this.mazeManager.tileSize);
     this.keyCountText = this.add.text(this.mazeManager.tileSize / 2, 0, '', {
@@ -223,7 +226,10 @@ class GameScene extends Phaser.Scene {
         this.updateKeyDisplay();
         const icon = Characters.createKey(this);
         icon.setDisplaySize(this.mazeManager.tileSize, this.mazeManager.tileSize);
-        icon.setPosition(this.heroSprite.x, this.heroSprite.y - this.mazeManager.tileSize);
+        icon.setPosition(
+          this.heroSprite.x,
+          this.heroSprite.y - this.mazeManager.tileSize + 5
+        );
         this.worldLayer.add(icon);
         this.tweens.add({
           targets: icon,
@@ -298,7 +304,7 @@ class GameScene extends Phaser.Scene {
     }
 
     this.keyDisplay.x = this.heroSprite.x - 10;
-    this.keyDisplay.y = this.heroSprite.y - this.mazeManager.tileSize;
+    this.keyDisplay.y = this.heroSprite.y - this.mazeManager.tileSize + 5;
 
     this.hero.moveTo(this.heroSprite.x, this.heroSprite.y);
 


### PR DESCRIPTION
## Summary
- shift the persistent key icon 5px lower
- match the chest key pickup animation with the new position

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68834e1afb988333b1e628ac2d794bde