### PR TITLE
Add pick up sound for oxygen

### DIFF
--- a/game.js
+++ b/game.js
@@ -237,6 +237,7 @@ class GameScene extends Phaser.Scene {
 
       if (curTile.cell === TILE.OXYGEN && curTile.chunk.chunk.airTank && !curTile.chunk.chunk.airTank.collected) {
         this.mazeManager.removeAirTank(curTile.chunk);
+        this.sound.play('pick_up');
         this.hero.oxygen = Math.min(this.hero.oxygen + 5, this.hero.maxOxygen);
         this.events.emit('updateOxygen', this.hero.oxygen / this.hero.maxOxygen);
       }

--- a/loading_scene.js
+++ b/loading_scene.js
@@ -48,6 +48,7 @@ export default class LoadingScene extends Phaser.Scene {
     this.load.audio('chunk_generate_2', 'assets/sounds/05_chunk_generate_02.wav');
     this.load.audio('midpoint', 'assets/sounds/06_midpoint.wav');
     this.load.audio('game_over', 'assets/sounds/07_game_over.wav');
+    this.load.audio('pick_up', 'assets/sounds/08_pick_up.wav');
     this.load.audio('bgm', 'assets/sounds/music_ambience.wav');
   }
 


### PR DESCRIPTION
## Summary
- load 08_pick_up.wav sound asset
- play new sound when collecting an oxygen tank

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68834db5f2088333808d61bb1302c1df