### PR TITLE
Fix repeated oxygen pickup sound

### DIFF
--- a/game.js
+++ b/game.js
@@ -235,11 +235,22 @@ class GameScene extends Phaser.Scene {
         this.events.emit('updateKeys', this.hero.keys);
       }
 
-      if (curTile.cell === TILE.OXYGEN && curTile.chunk.chunk.airTank && !curTile.chunk.chunk.airTank.collected) {
+      if (
+        curTile.cell === TILE.OXYGEN &&
+        curTile.chunk.chunk.airTank &&
+        !curTile.chunk.chunk.airTank.collected
+      ) {
+        curTile.chunk.chunk.airTank.collected = true;
         this.mazeManager.removeAirTank(curTile.chunk);
         this.sound.play('pick_up');
-        this.hero.oxygen = Math.min(this.hero.oxygen + 5, this.hero.maxOxygen);
-        this.events.emit('updateOxygen', this.hero.oxygen / this.hero.maxOxygen);
+        this.hero.oxygen = Math.min(
+          this.hero.oxygen + 5,
+          this.hero.maxOxygen
+        );
+        this.events.emit(
+          'updateOxygen',
+          this.hero.oxygen / this.hero.maxOxygen
+        );
       }
 
       if (curTile.cell === TILE.SILVER_DOOR && this.hero.keys > 0) {


### PR DESCRIPTION
## Summary
- ensure the oxygen tank pickup sound only plays once

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68835151e5e4833380f3ab7cc582bbb2