### PR TITLE
Add oxygen supply console SVG asset

### DIFF
--- a/assets/images/oxygen_supply_console.svg
+++ b/assets/images/oxygen_supply_console.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="body" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a7d7f9"/>
+      <stop offset="100%" stop-color="#296c9c"/>
+    </linearGradient>
+    <radialGradient id="highlight" cx="0.3" cy="0.2" r="0.7">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.7"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="1" stdDeviation="1" flood-color="#000" flood-opacity="0.5"/>
+    </filter>
+  </defs>
+  <!-- Machine body -->
+  <g filter="url(#shadow)">
+    <rect x="4" y="4" width="24" height="24" rx="3" fill="url(#body)" stroke="#224b6c" stroke-width="1.5"/>
+    <rect x="4" y="4" width="24" height="24" rx="3" fill="url(#highlight)"/>
+  </g>
+  <!-- Display -->
+  <rect x="8" y="7" width="16" height="10" rx="1" fill="#001a26" stroke="#67e2ff" stroke-width="1"/>
+  <text x="16" y="14" text-anchor="middle" dominant-baseline="middle" font-family="Arial" font-size="6" fill="#67e2ff">O₂</text>
+  <!-- Gauge -->
+  <circle cx="16" cy="22" r="5" fill="#ffffff" stroke="#224b6c" stroke-width="1.5"/>
+  <line x1="16" y1="22" x2="20" y2="20" stroke="#224b6c" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
## Summary
- add a new oxygen supply console SVG graphic

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68835cac0a1483338902ff779a024c33