### PR TITLE
Update hero SVG with taller design

### DIFF
--- a/assets/images/hero.svg
+++ b/assets/images/hero.svg
@@ -5,18 +5,6 @@
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
   </defs>
-  <!-- Head -->
-  <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
-  <ellipse cx="8" cy="14" rx="4" ry="2" fill="#8cc84b"/>
-  <ellipse cx="24" cy="14" rx="4" ry="2" fill="#8cc84b"/>
-  <circle cx="10" cy="6" r="4" fill="#ffffff"/>
-  <circle cx="22" cy="6" r="4" fill="#ffffff"/>
-  <circle cx="10" cy="6" r="2" fill="#000000"/>
-  <circle cx="22" cy="6" r="2" fill="#000000"/>
-  <path d="M12 12 Q16 16 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
-  <path d="M8 10 C10 8, 22 8, 24 10" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
-  <!-- Helmet -->
-  <circle cx="16" cy="12" r="12" fill="#e0f7ff" fill-opacity="0.5" stroke="#99ccff" stroke-width="2"/>
   <!-- Body -->
   <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <!-- Suit Torso -->
@@ -33,4 +21,16 @@
   <!-- Boots -->
   <rect x="8" y="36" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
   <rect x="18" y="36" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <ellipse cx="8" cy="14" rx="4" ry="2" fill="#8cc84b"/>
+  <ellipse cx="24" cy="14" rx="4" ry="2" fill="#8cc84b"/>
+  <circle cx="10" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="22" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="10" cy="6" r="2" fill="#000000"/>
+  <circle cx="22" cy="6" r="2" fill="#000000"/>
+  <path d="M12 12 Q16 16 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M8 10 C10 8, 22 8, 24 10" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Helmet -->
+  <circle cx="16" cy="12" r="12" fill="#e0f7ff" fill-opacity="0.5" stroke="#99ccff" stroke-width="2"/>
 </svg>

--- a/assets/images/hero.svg
+++ b/assets/images/hero.svg
@@ -1,22 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
   <defs>
     <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#aee868"/>
       <stop offset="100%" stop-color="#6aa84f"/>
     </linearGradient>
   </defs>
-  <!-- Body -->
-  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
-  <!-- Suit Torso -->
-  <rect x="10" y="18" width="12" height="14" rx="3" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
-  <!-- Suit Arms -->
-  <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
-  <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
-  <!-- Suit Belt -->
-  <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
-  <!-- Legs -->
-  <ellipse cx="11" cy="34" rx="4" ry="2" fill="#8cc84b"/>
-  <ellipse cx="21" cy="34" rx="4" ry="2" fill="#8cc84b"/>
   <!-- Head -->
   <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <ellipse cx="8" cy="14" rx="4" ry="2" fill="#8cc84b"/>
@@ -29,4 +17,20 @@
   <path d="M8 10 C10 8, 22 8, 24 10" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
   <!-- Helmet -->
   <circle cx="16" cy="12" r="12" fill="#e0f7ff" fill-opacity="0.5" stroke="#99ccff" stroke-width="2"/>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <!-- Suit Torso -->
+  <rect x="10" y="18" width="12" height="14" rx="3" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <!-- Suit Arms -->
+  <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
+  <!-- Suit Belt with buckle detail -->
+  <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <rect x="15" y="26" width="2" height="3" fill="#808080"/>
+  <!-- Legs -->
+  <ellipse cx="11" cy="34" rx="4" ry="2" fill="#8cc84b"/>
+  <ellipse cx="21" cy="34" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Boots -->
+  <rect x="8" y="36" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
+  <rect x="18" y="36" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
 </svg>

--- a/assets/images/hero_back_walk1.svg
+++ b/assets/images/hero_back_walk1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
   <defs>
     <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#aee868"/>
@@ -16,11 +16,15 @@
   <!-- Suit Arms -->
   <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
   <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
-  <!-- Suit Belt -->
+  <!-- Suit Belt with buckle detail -->
   <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <rect x="15" y="26" width="2" height="3" fill="#808080"/>
   <!-- Legs -->
   <ellipse cx="11" cy="34" rx="4" ry="2" fill="#8cc84b"/>
   <ellipse cx="21" cy="34" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Boots -->
+  <rect x="8" y="36" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
+  <rect x="18" y="36" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
   <!-- Oxygen Tank -->
   <g id="tank">
     <rect x="11" y="15" width="10" height="15" rx="3" fill="url(#tankGrad)" stroke="#2b6f95" stroke-width="1.5"/>

--- a/assets/images/hero_back_walk2.svg
+++ b/assets/images/hero_back_walk2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
   <defs>
     <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#aee868"/>
@@ -16,11 +16,15 @@
   <!-- Suit Arms -->
   <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
   <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
-  <!-- Suit Belt -->
+  <!-- Suit Belt with buckle detail -->
   <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <rect x="15" y="26" width="2" height="3" fill="#808080"/>
   <!-- Legs -->
   <ellipse cx="11" cy="32" rx="4" ry="2" fill="#8cc84b"/>
   <ellipse cx="21" cy="36" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Boots -->
+  <rect x="8" y="34" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
+  <rect x="18" y="38" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
   <!-- Oxygen Tank -->
   <g id="tank">
     <rect x="11" y="15" width="10" height="15" rx="3" fill="url(#tankGrad)" stroke="#2b6f95" stroke-width="1.5"/>

--- a/assets/images/hero_back_walk3.svg
+++ b/assets/images/hero_back_walk3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
   <defs>
     <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#aee868"/>
@@ -16,11 +16,15 @@
   <!-- Suit Arms -->
   <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
   <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
-  <!-- Suit Belt -->
+  <!-- Suit Belt with buckle detail -->
   <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <rect x="15" y="26" width="2" height="3" fill="#808080"/>
   <!-- Legs -->
   <ellipse cx="11" cy="36" rx="4" ry="2" fill="#8cc84b"/>
   <ellipse cx="21" cy="32" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Boots -->
+  <rect x="8" y="38" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
+  <rect x="18" y="34" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
   <!-- Oxygen Tank -->
   <g id="tank">
     <rect x="11" y="15" width="10" height="15" rx="3" fill="url(#tankGrad)" stroke="#2b6f95" stroke-width="1.5"/>

--- a/assets/images/hero_right_walk1.svg
+++ b/assets/images/hero_right_walk1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
   <defs>
     <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#aee868"/>
@@ -15,11 +15,15 @@
   <rect x="10" y="18" width="12" height="14" rx="3" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
   <!-- Suit Arms -->
   <rect x="16" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
-  <!-- Suit Belt -->
+  <!-- Suit Belt with buckle detail -->
   <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <rect x="15" y="26" width="2" height="3" fill="#808080"/>
   <!-- Legs -->
   <ellipse cx="11" cy="34" rx="4" ry="2" fill="#8cc84b"/>
   <ellipse cx="21" cy="34" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Boots -->
+  <rect x="8" y="36" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
+  <rect x="18" y="36" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
   <!-- Oxygen Tank -->
   <g id="tank">
     <rect x="9" y="15" width="10" height="15" rx="3" fill="url(#tankGrad)" stroke="#2b6f95" stroke-width="1.5"/>

--- a/assets/images/hero_right_walk2.svg
+++ b/assets/images/hero_right_walk2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
   <defs>
     <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#aee868"/>
@@ -15,11 +15,15 @@
   <rect x="10" y="18" width="12" height="14" rx="3" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
   <!-- Suit Arms -->
   <rect x="16" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
-  <!-- Suit Belt -->
+  <!-- Suit Belt with buckle detail -->
   <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <rect x="15" y="26" width="2" height="3" fill="#808080"/>
   <!-- Legs -->
   <ellipse cx="11" cy="32" rx="4" ry="2" fill="#8cc84b"/>
   <ellipse cx="21" cy="36" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Boots -->
+  <rect x="8" y="34" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
+  <rect x="18" y="38" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
   <!-- Oxygen Tank -->
   <g id="tank">
     <rect x="9" y="15" width="10" height="15" rx="3" fill="url(#tankGrad)" stroke="#2b6f95" stroke-width="1.5"/>

--- a/assets/images/hero_right_walk3.svg
+++ b/assets/images/hero_right_walk3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
   <defs>
     <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#aee868"/>
@@ -15,11 +15,15 @@
   <rect x="10" y="18" width="12" height="14" rx="3" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
   <!-- Suit Arms -->
   <rect x="16" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
-  <!-- Suit Belt -->
+  <!-- Suit Belt with buckle detail -->
   <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <rect x="15" y="26" width="2" height="3" fill="#808080"/>
   <!-- Legs -->
   <ellipse cx="11" cy="36" rx="4" ry="2" fill="#8cc84b"/>
   <ellipse cx="21" cy="32" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Boots -->
+  <rect x="8" y="38" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
+  <rect x="18" y="34" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
   <!-- Oxygen Tank -->
   <g id="tank">
     <rect x="9" y="15" width="10" height="15" rx="3" fill="url(#tankGrad)" stroke="#2b6f95" stroke-width="1.5"/>

--- a/assets/images/hero_walk1.svg
+++ b/assets/images/hero_walk1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
   <defs>
     <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#aee868"/>
@@ -12,11 +12,15 @@
   <!-- Suit Arms -->
   <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
   <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
-  <!-- Suit Belt -->
+  <!-- Suit Belt with buckle detail -->
   <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <rect x="15" y="26" width="2" height="3" fill="#808080"/>
   <!-- Legs -->
   <ellipse cx="11" cy="34" rx="4" ry="2" fill="#8cc84b"/>
   <ellipse cx="21" cy="34" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Boots -->
+  <rect x="8" y="36" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
+  <rect x="18" y="36" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
   <!-- Head -->
   <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <ellipse cx="8" cy="14" rx="4" ry="2" fill="#8cc84b"/>

--- a/assets/images/hero_walk2.svg
+++ b/assets/images/hero_walk2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
   <defs>
     <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#aee868"/>
@@ -12,11 +12,15 @@
   <!-- Suit Arms -->
   <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
   <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
-  <!-- Suit Belt -->
+  <!-- Suit Belt with buckle detail -->
   <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <rect x="15" y="26" width="2" height="3" fill="#808080"/>
   <!-- Legs -->
   <ellipse cx="11" cy="32" rx="4" ry="2" fill="#8cc84b"/>
   <ellipse cx="21" cy="36" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Boots -->
+  <rect x="8" y="34" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
+  <rect x="18" y="38" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
   <!-- Head -->
   <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <ellipse cx="8" cy="13" rx="4" ry="2" fill="#8cc84b"/>

--- a/assets/images/hero_walk3.svg
+++ b/assets/images/hero_walk3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="40">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
   <defs>
     <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#aee868"/>
@@ -12,11 +12,15 @@
   <!-- Suit Arms -->
   <rect x="5" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
   <rect x="22" y="21" width="5" height="9" rx="2" fill="#ffffff" stroke="#b0b0b0" stroke-width="2"/>
-  <!-- Suit Belt -->
+  <!-- Suit Belt with buckle detail -->
   <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <rect x="15" y="26" width="2" height="3" fill="#808080"/>
   <!-- Legs -->
   <ellipse cx="11" cy="36" rx="4" ry="2" fill="#8cc84b"/>
   <ellipse cx="21" cy="32" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Boots -->
+  <rect x="8" y="38" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
+  <rect x="18" y="34" width="6" height="6" rx="1" fill="#4e5d39" stroke="#2d3724" stroke-width="1"/>
   <!-- Head -->
   <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
   <ellipse cx="8" cy="15" rx="4" ry="2" fill="#8cc84b"/>


### PR DESCRIPTION
## Summary
- enlarge hero SVG canvas from 40px height to 46px
- reorder drawing elements from head downwards
- add belt buckle and boot details

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68835c0e39608333b98114588c2e9038