### PR TITLE
Add oxygen console tether effect

### DIFF
--- a/characters.js
+++ b/characters.js
@@ -20,6 +20,7 @@ const SPRITES = {
   arrow: 'arrow.svg',
   key: 'key.svg',
   air_tank: 'air_tank.svg',
+  oxygen_console: 'oxygen_supply_console.svg',
   spikes: 'floor_spikes.svg'
 };
 
@@ -93,6 +94,10 @@ function createAirTank(scene) {
   return scene.add.image(0, 0, 'air_tank').setOrigin(0);
 }
 
+function createOxygenConsole(scene) {
+  return scene.add.image(0, 0, 'oxygen_console').setOrigin(0);
+}
+
 function createSpike(scene) {
   return scene.add.image(0, 0, 'spikes').setOrigin(0);
 }
@@ -117,6 +122,7 @@ export default {
   createTreasure,
   createKey,
   createAirTank,
+  createOxygenConsole,
   createSpike,
   createHero,
   createArrow

--- a/game.js
+++ b/game.js
@@ -410,7 +410,20 @@ class GameScene extends Phaser.Scene {
       this.oxygenLine.lineStyle(2, 0xffffff, 1);
       this.oxygenLine.beginPath();
       this.oxygenLine.moveTo(cx, cy);
-      this.oxygenLine.quadraticBezierTo(midX, midY, hx, hy);
+      const segments = 16;
+      for (let i = 1; i <= segments; i++) {
+        const t = i / segments;
+        const inv = 1 - t;
+        const px =
+          inv * inv * cx +
+          2 * inv * t * midX +
+          t * t * hx;
+        const py =
+          inv * inv * cy +
+          2 * inv * t * midY +
+          t * t * hy;
+        this.oxygenLine.lineTo(px, py);
+      }
       this.oxygenLine.strokePath();
       this.oxygenLine.setDepth(hy > cy ? 9 : 11);
     }

--- a/game.js
+++ b/game.js
@@ -113,10 +113,24 @@ class GameScene extends Phaser.Scene {
           const hy = this.heroSprite.y;
           const cx = this.oxygenConsole.x;
           const cy = this.oxygenConsole.y;
+          const dx = hx - cx;
+          const dy = hy - cy;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          const sag = Math.min(this.mazeManager.tileSize, dist / 4);
+          const midX = (hx + cx) / 2;
+          const midY = Math.max(hy, cy) + sag;
           const steps = 5;
           for (let i = 0; i < steps; i++) {
-            const px = cx + ((hx - cx) * i) / steps;
-            const py = cy + ((hy - cy) * i) / steps;
+            const t = i / steps;
+            const inv = 1 - t;
+            const px =
+              inv * inv * cx +
+              2 * inv * t * midX +
+              t * t * hx;
+            const py =
+              inv * inv * cy +
+              2 * inv * t * midY +
+              t * t * hy;
             this.time.delayedCall(i * 40, () => {
               evaporateArea(this, px - 4, py - 4, 8, 8, 0xffffff);
             });
@@ -386,11 +400,17 @@ class GameScene extends Phaser.Scene {
       const hy = this.heroSprite.y;
       const cx = this.oxygenConsole.x;
       const cy = this.oxygenConsole.y;
+      const dx = hx - cx;
+      const dy = hy - cy;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      const sag = Math.min(this.mazeManager.tileSize, dist / 4);
+      const midX = (hx + cx) / 2;
+      const midY = Math.max(hy, cy) + sag;
       this.oxygenLine.clear();
       this.oxygenLine.lineStyle(2, 0xffffff, 1);
       this.oxygenLine.beginPath();
       this.oxygenLine.moveTo(cx, cy);
-      this.oxygenLine.lineTo(hx, hy);
+      this.oxygenLine.quadraticBezierTo(midX, midY, hx, hy);
       this.oxygenLine.strokePath();
       this.oxygenLine.setDepth(hy > cy ? 9 : 11);
     }

--- a/maze_manager.js
+++ b/maze_manager.js
@@ -41,6 +41,7 @@ export default class MazeManager {
     const { size } = pickMazeConfig(1);
     const chunk = createChunk(this._nextSeed(), size, 'W');
     this._ensureEntrance(chunk);
+    this._addOxygenConsole(chunk);
     return this.addChunk(chunk, 0, 0);
   }
 
@@ -64,6 +65,8 @@ export default class MazeManager {
       doorSprite: null,
       chestSprite: null,
       airTankSprite: null,
+      oxygenSprite: null,
+      oxygenPosition: null,
       silverDoors: [],
       spikeSprites: []
     };
@@ -88,6 +91,11 @@ export default class MazeManager {
         switch (tile) {
           case TILE.WALL:
             sprite = Characters.createWall(this.scene);
+            break;
+          case TILE.SPECIAL:
+            sprite = Characters.createOxygenConsole(this.scene);
+            info.oxygenSprite = sprite;
+            info.oxygenPosition = { x, y };
             break;
           case TILE.DOOR:
             sprite = Characters.createExit(this.scene);
@@ -436,6 +444,24 @@ export default class MazeManager {
     );
     t[y * size + x] = TILE.OXYGEN;
     chunk.airTank = { x, y, collected: false };
+  }
+
+  _addOxygenConsole(chunk) {
+    const size = chunk.size;
+    const t = chunk.tiles;
+    const candidates = [];
+    for (let y = 1; y < size - 1; y++) {
+      for (let x = 1; x < size - 1; x++) {
+        if (t[y * size + x] !== TILE.WALL) continue;
+        if (this._isNearEntranceOrExit(chunk, x, y)) continue;
+        candidates.push({ x, y });
+      }
+    }
+    if (candidates.length) {
+      const spot = candidates[Math.floor(Math.random() * candidates.length)];
+      t[spot.y * size + spot.x] = TILE.SPECIAL;
+      chunk.oxygenConsole = { x: spot.x, y: spot.y };
+    }
   }
 
   _addSpikes(chunk) {


### PR DESCRIPTION
## Summary
- show new sprite `oxygen_supply_console.svg` as an oxygen console
- place the console in the first chunk by replacing a wall
- connect the hero to the console with a white tether that changes layer based on Y
- dissolve the tether when moving to the second chunk

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68837833668c83338b339a42c2adbdf1