### PR TITLE
Fix syntax error in maze_manager

### DIFF
--- a/maze_manager.js
+++ b/maze_manager.js
@@ -68,7 +68,7 @@ export default class MazeManager {
       oxygenSprite: null,
       oxygenPosition: null,
       silverDoors: [],
-      autoGates: []
+      autoGates: [],
       spikeSprites: []
     };
     this.renderChunk(chunk, container, info);


### PR DESCRIPTION
## Summary
- add a missing comma in `maze_manager.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883820da41483339e991d040591afed