### PR TITLE
Add floor switch asset

### DIFF
--- a/assets/images/floor_switch_red.svg
+++ b/assets/images/floor_switch_red.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <defs>
+    <linearGradient id="base" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#777"/>
+      <stop offset="100%" stop-color="#333"/>
+    </linearGradient>
+    <radialGradient id="button" cx="0.3" cy="0.3" r="0.7">
+      <stop offset="0%" stop-color="#ff8888"/>
+      <stop offset="100%" stop-color="#cc0000"/>
+    </radialGradient>
+  </defs>
+  <!-- Base plate -->
+  <rect x="6" y="12" width="20" height="8" rx="2" fill="url(#base)" stroke="#555" stroke-width="2"/>
+  <!-- Red button -->
+  <ellipse cx="16" cy="16" rx="6" ry="3" fill="url(#button)" stroke="#770000" stroke-width="2"/>
+</svg>


### PR DESCRIPTION
## Summary
- create a `floor_switch_red.svg` for a red switch that can be displayed over floor tiles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688387db487c8333aec4e03f0c5f04a8