### PR TITLE
Add meteor collisions with new shield

### DIFF
--- a/src/characters.js
+++ b/src/characters.js
@@ -23,7 +23,11 @@ const SPRITES = {
   key: 'key.svg',
   air_tank: 'air_tank.svg',
   oxygen_console: 'oxygen_supply_console.svg',
-  spikes: 'floor_spikes.svg'
+  spikes: 'floor_spikes.svg',
+  meteor: 'meteor.svg',
+  meteor_explosion1: 'meteor_explosion1.svg',
+  meteor_explosion2: 'meteor_explosion2.svg',
+  meteor_explosion3: 'meteor_explosion3.svg'
 };
 
 const canvases = {};
@@ -112,6 +116,14 @@ function createSpike(scene) {
   return scene.add.image(0, 0, 'spikes').setOrigin(0);
 }
 
+function createMeteor(scene) {
+  return scene.add.image(0, 0, 'meteor').setOrigin(0.5);
+}
+
+function createMeteorExplosion(scene) {
+  return scene.add.image(0, 0, 'meteor_explosion1').setOrigin(0.5);
+}
+
 function createHero(scene) {
   return scene.add.image(0, 0, 'hero_idle').setOrigin(0.5);
 }
@@ -136,6 +148,8 @@ export default {
   createAirTank,
   createOxygenConsole,
   createSpike,
+  createMeteor,
+  createMeteorExplosion,
   createHero,
   createArrow
 };

--- a/src/game.js
+++ b/src/game.js
@@ -11,6 +11,8 @@ import LoadingScene from './loading_scene.js';
 import StarField from './star_field.js';
 import GameOverScene from './game_over_scene.js';
 import { computeTetherPoints, isHorizontal, isVertical } from './utils.js';
+import Shield from './shield.js';
+import MeteorField from './meteor_field.js';
 
 const MIDPOINTS = [5, 10, 15, 20, 30, 40, 50];
 
@@ -52,6 +54,8 @@ class GameScene extends Phaser.Scene {
 
     this.cameraManager = new CameraManager(this, this.mazeManager);
     this.starField = new StarField(this);
+    this.shield = new Shield(this, this.mazeManager);
+    this.meteorField = new MeteorField(this, this.shield);
     this._seenFirstChunk = false;
     this.mazeManager.events.on('chunk-created', info => {
       this.cameraManager.expandBounds(info);
@@ -405,6 +409,14 @@ class GameScene extends Phaser.Scene {
       }
       this.oxygenLine.strokePath();
       this.oxygenLine.setDepth(hy > cy ? 9 : 11);
+    }
+
+    if (this.shield) {
+      this.shield.update();
+    }
+
+    if (this.meteorField) {
+      this.meteorField.update();
     }
 
     // Prevent camera drift by re-centering if needed

--- a/src/meteor_field.js
+++ b/src/meteor_field.js
@@ -1,0 +1,97 @@
+export default class MeteorField {
+  constructor(scene, shield) {
+    this.scene = scene;
+    this.shield = shield;
+    this.container = scene.add.container(0, 0);
+    this.container.setDepth(-900);
+    this.container.setScrollFactor(0);
+    this.active = [];
+    this.spawnTimer = scene.time.addEvent({
+      delay: Phaser.Math.Between(5000, 10000),
+      loop: true,
+      callback: () => {
+        this.spawnMeteor();
+        this.spawnTimer.delay = Phaser.Math.Between(5000, 10000);
+      }
+    });
+  }
+
+  getEdgePos(edge, width, height, margin) {
+    switch (edge) {
+      case 'left':
+        return { x: -margin, y: Phaser.Math.Between(0, height) };
+      case 'right':
+        return { x: width + margin, y: Phaser.Math.Between(0, height) };
+      case 'top':
+        return { x: Phaser.Math.Between(0, width), y: -margin };
+      case 'bottom':
+      default:
+        return { x: Phaser.Math.Between(0, width), y: height + margin };
+    }
+  }
+
+  spawnMeteor() {
+    const cam = this.scene.cameras.main;
+    const width = cam.width;
+    const height = cam.height;
+    const margin = 32;
+    const edges = ['left', 'right', 'top', 'bottom'];
+    const startEdge = Phaser.Utils.Array.GetRandom(edges);
+    const opposite = { left: 'right', right: 'left', top: 'bottom', bottom: 'top' };
+    const destEdge = opposite[startEdge];
+    const start = this.getEdgePos(startEdge, width, height, margin);
+    const dest = this.getEdgePos(destEdge, width, height, margin);
+    const meteor = this.scene.add.image(start.x, start.y, 'meteor').setOrigin(0.5);
+    this.container.add(meteor);
+    this.active.push(meteor);
+    const distance = Phaser.Math.Distance.Between(start.x, start.y, dest.x, dest.y);
+    const speed = 80;
+    const duration = (distance / speed) * 1000;
+    const rotSpeed = Phaser.Math.FloatBetween(-90, 90);
+    this.scene.tweens.add({
+      targets: meteor,
+      x: dest.x,
+      y: dest.y,
+      angle: rotSpeed * duration / 1000,
+      duration,
+      ease: 'Linear',
+      onComplete: () => this.removeMeteor(meteor)
+    });
+  }
+
+  removeMeteor(m) {
+    const idx = this.active.indexOf(m);
+    if (idx !== -1) this.active.splice(idx, 1);
+    m.destroy();
+  }
+
+  showExplosion(x, y) {
+    const img = this.scene.add.image(x, y, 'meteor_explosion1').setOrigin(0.5);
+    img.setDepth(-850);
+    img.setScrollFactor(0);
+    this.container.add(img);
+    this.scene.time.delayedCall(100, () => img.setTexture('meteor_explosion2'));
+    this.scene.time.delayedCall(200, () => img.setTexture('meteor_explosion3'));
+    this.scene.time.delayedCall(300, () => img.destroy());
+  }
+
+  update() {
+    const shieldPos = this.shield.getScreenPosition();
+    const r2 = this.shield.radius * this.shield.radius;
+    for (const m of [...this.active]) {
+      const dx = m.x - shieldPos.x;
+      const dy = m.y - shieldPos.y;
+      if (dx * dx + dy * dy <= r2) {
+        this.showExplosion(m.x, m.y);
+        this.shield.flash();
+        this.removeMeteor(m);
+      }
+    }
+  }
+
+  destroy() {
+    if (this.spawnTimer) this.spawnTimer.remove();
+    this.active.forEach(m => m.destroy());
+    this.container.destroy();
+  }
+}

--- a/src/shield.js
+++ b/src/shield.js
@@ -1,0 +1,42 @@
+export default class Shield {
+  constructor(scene, mazeManager) {
+    this.scene = scene;
+    this.mazeManager = mazeManager;
+    this.radius = 10;
+    this.arc = scene.add.circle(0, 0, this.radius, 0x3388ff, 0);
+    this.arc.setDepth(8);
+    this.arc.setScrollFactor(0);
+  }
+
+  getCurrentChunk() {
+    if (!this.mazeManager.activeChunks.length) return null;
+    return this.mazeManager.activeChunks[this.mazeManager.activeChunks.length - 1];
+  }
+
+  update() {
+    const info = this.getCurrentChunk();
+    if (!info) return;
+    const size = info.chunk.size * this.mazeManager.tileSize;
+    const r = (size * 1.3) / 2;
+    if (r !== this.radius) {
+      this.radius = r;
+      this.arc.setRadius(this.radius);
+    }
+    const { x, y } = this.mazeManager.getChunkCenter(info);
+    const cam = this.scene.cameras.main;
+    this.arc.setPosition(x - cam.scrollX, y - cam.scrollY);
+  }
+
+  getScreenPosition() {
+    return { x: this.arc.x, y: this.arc.y };
+  }
+
+  flash() {
+    this.arc.setFillStyle(0x3388ff, 0.5);
+    this.scene.tweens.add({
+      targets: this.arc,
+      fillAlpha: 0,
+      duration: 300
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add meteor and explosion sprites to sprite manager
- implement Shield component to highlight current chunk
- implement MeteorField for periodic meteor spawns
- render the shield and meteors in GameScene

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68838cc5dbc08333a58db0254acd18c5