### PR TITLE
Shorten hero vanish effect

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -429,13 +429,13 @@ class GameScene extends Phaser.Scene {
     evaporate();
     const evapTimer = this.time.addEvent({
       delay: 100,
-      repeat: 19,
+      repeat: 15,
       callback: evaporate
     });
 
     this.heroSprite.setVisible(false);
 
-    this.time.delayedCall(2000, () => {
+    this.time.delayedCall(1600, () => {
       evapTimer.remove();
       this.heroSprite.destroy();
       this.scene.launch('GameOverScene');

--- a/src/game.js
+++ b/src/game.js
@@ -429,13 +429,13 @@ class GameScene extends Phaser.Scene {
     evaporate();
     const evapTimer = this.time.addEvent({
       delay: 100,
-      repeat: 7,
+      repeat: 5,
       callback: evaporate
     });
 
     this.heroSprite.setVisible(false);
 
-    this.time.delayedCall(1200, () => {
+    this.time.delayedCall(1000, () => {
       evapTimer.remove();
       this.heroSprite.destroy();
       this.scene.launch('GameOverScene');

--- a/src/game.js
+++ b/src/game.js
@@ -423,19 +423,19 @@ class GameScene extends Phaser.Scene {
         this.heroSprite.y - size,
         size,
         size * 2,
-        0x000000
+        0xaee868
       );
     };
     evaporate();
     const evapTimer = this.time.addEvent({
       delay: 100,
-      repeat: 15,
+      repeat: 7,
       callback: evaporate
     });
 
     this.heroSprite.setVisible(false);
 
-    this.time.delayedCall(1600, () => {
+    this.time.delayedCall(1200, () => {
       evapTimer.remove();
       this.heroSprite.destroy();
       this.scene.launch('GameOverScene');


### PR DESCRIPTION
## Summary
- reduce hero evaporate particles to finish in 1.6 seconds when oxygen runs out

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883921663148333a41098578890e894