### PR TITLE
Add hero without spacesuit SVG

### DIFF
--- a/assets/images/hero_plain.svg
+++ b/assets/images/hero_plain.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#aee868"/>
+      <stop offset="100%" stop-color="#6aa84f"/>
+    </linearGradient>
+  </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <!-- Legs -->
+  <ellipse cx="11" cy="34" rx="4" ry="2" fill="#8cc84b"/>
+  <ellipse cx="21" cy="34" rx="4" ry="2" fill="#8cc84b"/>
+  <!-- Head -->
+  <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#4e7c3a" stroke-width="2"/>
+  <ellipse cx="8" cy="14" rx="4" ry="2" fill="#8cc84b"/>
+  <ellipse cx="24" cy="14" rx="4" ry="2" fill="#8cc84b"/>
+  <circle cx="10" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="22" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="10" cy="6" r="2" fill="#000000"/>
+  <circle cx="22" cy="6" r="2" fill="#000000"/>
+  <path d="M12 12 Q16 16 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M8 10 C10 8, 22 8, 24 10" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+</svg>

--- a/assets/images/sleep_pod.svg
+++ b/assets/images/sleep_pod.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
+  <defs>
+    <linearGradient id="podGray" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d0d0d0"/>
+      <stop offset="100%" stop-color="#888888"/>
+    </linearGradient>
+    <linearGradient id="glassBlue" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#e0f7ff"/>
+      <stop offset="100%" stop-color="#a0d8ff"/>
+    </linearGradient>
+  </defs>
+  <!-- Pod back shell -->
+  <rect x="4" y="2" width="24" height="42" rx="10" fill="url(#podGray)" stroke="#606060" stroke-width="2"/>
+  <!-- Front glass window -->
+  <rect x="7" y="6" width="18" height="34" rx="8" fill="url(#glassBlue)" stroke="#77aadd" stroke-width="1.5" fill-opacity="0.7"/>
+</svg>

--- a/src/characters.js
+++ b/src/characters.js
@@ -9,6 +9,7 @@ const SPRITES = {
   auto_gate_closed: 'auto_gate_closed.svg',
   door_open: 'airlock_open.svg',
   treasure: 'treasure.svg',
+  hero_plain: 'hero_plain.svg',
   hero_idle: 'hero.svg',
   hero_walk1: 'hero_walk1.svg',
   hero_walk2: 'hero_walk2.svg',
@@ -116,6 +117,10 @@ function createHero(scene) {
   return scene.add.image(0, 0, 'hero_idle').setOrigin(0.5);
 }
 
+function createHeroPlain(scene) {
+  return scene.add.image(0, 0, 'hero_plain').setOrigin(0.5);
+}
+
 function createArrow(scene) {
   return scene.add.image(0, 0, 'arrow').setOrigin(0.5);
 }
@@ -137,5 +142,6 @@ export default {
   createOxygenConsole,
   createSpike,
   createHero,
+  createHeroPlain,
   createArrow
 };

--- a/src/characters.js
+++ b/src/characters.js
@@ -9,6 +9,7 @@ const SPRITES = {
   auto_gate_closed: 'auto_gate_closed.svg',
   door_open: 'airlock_open.svg',
   treasure: 'treasure.svg',
+  sleep_pod: 'sleep_pod.svg',
   hero_plain: 'hero_plain.svg',
   hero_idle: 'hero.svg',
   hero_walk1: 'hero_walk1.svg',
@@ -113,6 +114,10 @@ function createSpike(scene) {
   return scene.add.image(0, 0, 'spikes').setOrigin(0);
 }
 
+function createSleepPod(scene) {
+  return scene.add.image(0, 0, 'sleep_pod').setOrigin(0);
+}
+
 function createHero(scene) {
   return scene.add.image(0, 0, 'hero_idle').setOrigin(0.5);
 }
@@ -141,6 +146,7 @@ export default {
   createAirTank,
   createOxygenConsole,
   createSpike,
+  createSleepPod,
   createHero,
   createHeroPlain,
   createArrow


### PR DESCRIPTION
## Summary
- add hero_plain.svg as a frog without spacesuit
- load hero_plain asset and expose `createHeroPlain` helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68839dee69948333826a42011ef4427a