### PR TITLE
Entrance door closes when exit opens

### DIFF
--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -49,6 +49,7 @@ export default class MazeManager {
       offsetX,
       offsetY,
       doorSprite: null,
+      entranceDoorSprite: null,
       chestSprite: null,
       airTankSprite: null,
       oxygenSprite: null,
@@ -324,6 +325,7 @@ export default class MazeManager {
     }
 
     const info = this.addChunk(chunk, offsetX, offsetY);
+    info.entranceDoorSprite = fromObj.doorSprite;
 
     heroSprite.x = offsetX + chunk.entrance.x * this.tileSize + this.tileSize / 2;
     heroSprite.y = offsetY + chunk.entrance.y * this.tileSize + this.tileSize / 2;
@@ -579,6 +581,9 @@ export default class MazeManager {
   openDoor(info) {
     if (info && info.doorSprite) {
       info.doorSprite.setTexture('door_open');
+    }
+    if (info && info.entranceDoorSprite) {
+      info.entranceDoorSprite.setTexture('exit');
     }
   }
 


### PR DESCRIPTION
## Summary
- track entrance door sprite when spawning new chunk
- close the entrance door whenever its chunk's exit door opens

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68839f7350888333801672134b8462eb