### PR TITLE
Fix syntax error in characters.js

### DIFF
--- a/src/characters.js
+++ b/src/characters.js
@@ -120,6 +120,7 @@ function createSpike(scene) {
 
 function createSleepPod(scene) {
   return scene.add.image(0, 0, 'sleep_pod').setOrigin(0);
+}
 
 function createMeteor(scene) {
   return scene.add.image(0, 0, 'meteor').setOrigin(0.5);


### PR DESCRIPTION
## Summary
- fix missing closing brace in characters.js causing syntax error

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6883a38b6d7c8333b716a75f8efe639e