### PR TITLE
Apply retro pixel filter to SVG assets

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -13,6 +13,7 @@ import GameOverScene from './game_over_scene.js';
 import { computeTetherPoints, isHorizontal, isVertical } from './utils.js';
 import Shield from './shield.js';
 import MeteorField from './meteor_field.js';
+import PixelRetroPipeline from './pixel_retro_pipeline.js';
 
 const MIDPOINTS = [5, 10, 15, 20, 30, 40, 50];
 
@@ -34,10 +35,16 @@ class GameScene extends Phaser.Scene {
     this.lastSpikeTile = null;
     this.oxygenLine = null;
     this.oxygenConsole = null;
+    this.retroPipeline = null;
   }
 
   preload() {
     Characters.registerTextures(this);
+    if (!this.renderer.pipelines.get('PixelRetro')) {
+      this.retroPipeline = this.renderer.pipelines.add('PixelRetro', new PixelRetroPipeline(this.game));
+    } else {
+      this.retroPipeline = this.renderer.pipelines.get('PixelRetro');
+    }
   }
 
   create() {
@@ -53,6 +60,10 @@ class GameScene extends Phaser.Scene {
     this.mazeManager = new MazeManager(this);
 
     this.cameraManager = new CameraManager(this, this.mazeManager);
+    if (this.retroPipeline) {
+      this.cameras.main.setRenderToTexture(this.retroPipeline);
+      this.retroPipeline.pixelSize = 4.0;
+    }
     this.starField = new StarField(this);
     this.shield = new Shield(this);
     this.meteorField = new MeteorField(this, this.shield, gameState.clearedMazes >= 40);

--- a/src/pixel_retro_pipeline.js
+++ b/src/pixel_retro_pipeline.js
@@ -1,0 +1,71 @@
+export default class PixelRetroPipeline extends Phaser.Renderer.WebGL.Pipelines.PostFXPipeline {
+  constructor(game) {
+    const fragShader = `
+precision mediump float;
+
+uniform sampler2D uMainSampler;
+uniform float pixelSize;
+uniform vec2 resolution;
+uniform vec3 palette[16];
+
+varying vec2 outTexCoord;
+
+vec3 nearestColor(vec3 c) {
+  float minDist = 1000.0;
+  vec3 nearest = palette[0];
+  for (int i = 0; i < 16; i++) {
+    vec3 p = palette[i];
+    float dist = distance(c, p);
+    if (dist < minDist) {
+      minDist = dist;
+      nearest = p;
+    }
+  }
+  return nearest;
+}
+
+void main() {
+  vec2 dxy = pixelSize / resolution;
+  vec2 coord = dxy * floor(outTexCoord / dxy);
+  vec4 col = texture2D(uMainSampler, coord);
+  vec3 q = nearestColor(col.rgb);
+  gl_FragColor = vec4(q, col.a);
+}
+`;
+    super({
+      game,
+      renderTarget: true,
+      fragShader
+    });
+    this.pixelSize = 4.0;
+    this.palette = [
+      [0.0, 0.0, 0.0],
+      [0.1137, 0.1686, 0.3255],
+      [0.4941, 0.1451, 0.3255],
+      [0.0, 0.5294, 0.3176],
+      [0.6706, 0.3216, 0.2118],
+      [0.3725, 0.3412, 0.3098],
+      [0.7608, 0.7647, 0.7804],
+      [1.0, 0.9451, 0.9098],
+      [1.0, 0.0, 0.3019],
+      [1.0, 0.6392, 0.0],
+      [1.0, 0.9255, 0.1529],
+      [0.0, 0.8941, 0.2118],
+      [0.1608, 0.6784, 1.0],
+      [0.5137, 0.4627, 0.6118],
+      [1.0, 0.4667, 0.6588],
+      [1.0, 0.8, 0.6667]
+    ];
+  }
+
+  onPreRender() {
+    this.set1f('pixelSize', this.pixelSize);
+    this.set2f('resolution', this.renderer.width, this.renderer.height);
+    const arr = [];
+    for (let i = 0; i < this.palette.length; i++) {
+      const c = this.palette[i];
+      arr.push(c[0], c[1], c[2]);
+    }
+    this.set3fv('palette', arr);
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `PixelRetroPipeline` applying pixelation and PICO-8 16‑color palette
- register the pipeline and apply it to the main camera

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6883b1f2c5088333a70ca42bbdc49160