### PR TITLE
Display cleared chunk count on game over

### DIFF
--- a/src/game_over_scene.js
+++ b/src/game_over_scene.js
@@ -23,14 +23,22 @@ export default class GameOverScene extends Phaser.Scene {
 
     this.letters = this.createFloatingText('RETRY?', VIRTUAL_WIDTH, VIRTUAL_HEIGHT);
 
+    // Show how many chunks the player cleared above the RETRY text
+    const cleared = `${gameState.clearedMazes} CHUNK`;
+    this.createFloatingText(cleared, VIRTUAL_WIDTH, VIRTUAL_HEIGHT - 80, 32);
+
     this.input.keyboard.once('keydown-W', () => this.restartGame());
     this.input.keyboard.once('keydown-A', () => this.restartGame());
     this.input.keyboard.once('keydown-S', () => this.restartGame());
     this.input.keyboard.once('keydown-D', () => this.restartGame());
   }
 
-  createFloatingText(str, centerX, y) {
-    const style = { fontFamily: 'monospace', fontSize: '48px', color: '#ffffff' };
+  createFloatingText(str, centerX, y, size = 48) {
+    const style = {
+      fontFamily: 'monospace',
+      fontSize: size + 'px',
+      color: '#ffffff'
+    };
     const measure = this.add.text(0, 0, str, style).setOrigin(0.5);
     const total = measure.width;
     measure.destroy();


### PR DESCRIPTION
## Summary
- show how many chunks the player cleared when the game ends
- allow floating text size customization

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884265148c8833388fa9da3d88b1f72