### PR TITLE
Add darker oxygen tank SVG

### DIFF
--- a/assets/images/air_tank_dark.svg
+++ b/assets/images/air_tank_dark.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="tankBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#9ebdcc"/>
+      <stop offset="100%" stop-color="#4182ad"/>
+    </linearGradient>
+    <radialGradient id="tankHighlight" cx="0.3" cy="0.3" r="0.6">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="1" stdDeviation="1" flood-color="#000000" flood-opacity="0.5"/>
+    </filter>
+  </defs>
+  <!-- Tank body -->
+  <g filter="url(#shadow)">
+    <rect x="5" y="6" width="22" height="22" rx="4" fill="url(#tankBody)" stroke="#225977" stroke-width="1.5"/>
+    <rect x="5" y="6" width="22" height="22" rx="4" fill="url(#tankHighlight)"/>
+  </g>
+  <!-- Valve -->
+  <g filter="url(#shadow)">
+    <rect x="13" y="2" width="6" height="4" rx="1" fill="#3ea6b4" stroke="#225977" stroke-width="1.5"/>
+    <circle cx="16" cy="4" r="2" fill="#ffffff" stroke="#225977" stroke-width="1.5"/>
+    <line x1="16" y1="4" x2="16" y2="2" stroke="#225977" stroke-width="1.5"/>
+    <line x1="16" y1="4" x2="18" y2="4" stroke="#225977" stroke-width="1.5"/>
+  </g>
+  <!-- Gauge -->
+  <g filter="url(#shadow)">
+    <circle cx="16" cy="18" r="5" fill="#ffffff" stroke="#225977" stroke-width="1.5"/>
+    <line x1="16" y1="18" x2="20" y2="16" stroke="#225977" stroke-width="1.5"/>
+  </g>
+  <!-- Decorative stripes -->
+  <g>
+    <rect x="5" y="18" width="22" height="2" fill="#679ecc"/>
+    <rect x="5" y="22" width="22" height="2" fill="#679ecc"/>
+  </g>
+  <!-- Central O₂ label overlay -->
+  <text x="16" y="16" text-anchor="middle" dominant-baseline="middle"
+        font-family="Arial" font-weight="bold" font-size="20"
+        fill="#ffffff" stroke="#000000" stroke-width="1" paint-order="stroke">O₂</text>
+</svg>


### PR DESCRIPTION
## Summary
- add a dark-colored version of the oxygen tank SVG

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68842d7a93bc83339377741b689354e1