### PR TITLE
Add electric machine hazard

### DIFF
--- a/src/characters.js
+++ b/src/characters.js
@@ -29,7 +29,8 @@ const SPRITES = {
   meteor: 'meteor.svg',
   meteor_explosion1: 'meteor_explosion1.svg',
   meteor_explosion2: 'meteor_explosion2.svg',
-  meteor_explosion3: 'meteor_explosion3.svg'
+  meteor_explosion3: 'meteor_explosion3.svg',
+  electric_machine: 'electric_machine.svg'
 };
 
 const canvases = {};
@@ -118,6 +119,10 @@ function createSpike(scene) {
   return scene.add.image(0, 0, 'spikes').setOrigin(0);
 }
 
+function createElectricMachine(scene) {
+  return scene.add.image(0, 0, 'electric_machine').setOrigin(0);
+}
+
 function createSleepPod(scene) {
   return scene.add.image(0, 0, 'sleep_pod').setOrigin(0);
 }
@@ -158,6 +163,7 @@ export default {
   createAirTank,
   createOxygenConsole,
   createSpike,
+  createElectricMachine,
   createSleepPod,
   createMeteor,
   createMeteorExplosion,

--- a/src/effects.js
+++ b/src/effects.js
@@ -108,13 +108,28 @@ export function evaporateArea(scene, x, y, width, height, color = 0xffffff) {
 export function createElectricCross(scene, x, y, size) {
   const gfx = scene.add.graphics();
   const half = size / 2;
-  gfx.lineStyle(2, 0x66ccff, 1);
-  gfx.beginPath();
-  gfx.moveTo(x - half, y);
-  gfx.lineTo(x + half, y);
-  gfx.moveTo(x, y - half);
-  gfx.lineTo(x, y + half);
-  gfx.strokePath();
+  const color = 0x66ccff;
+  gfx.lineStyle(2, color, 1);
+
+  const drawJagged = (x1, y1, x2, y2, steps = 3) => {
+    gfx.beginPath();
+    gfx.moveTo(x1, y1);
+    for (let i = 1; i < steps; i++) {
+      const t = i / steps;
+      const nx = Phaser.Math.Linear(x1, x2, t) + Phaser.Math.Between(-2, 2);
+      const ny = Phaser.Math.Linear(y1, y2, t) + Phaser.Math.Between(-2, 2);
+      gfx.lineTo(nx, ny);
+    }
+    gfx.lineTo(x2, y2);
+    gfx.strokePath();
+  };
+
+  drawJagged(x - half, y, x + half, y);
+  drawJagged(x, y - half, x, y + half);
+  drawJagged(x - half * 0.7, y - half * 0.7, x + half * 0.7, y + half * 0.7);
+  drawJagged(x - half * 0.7, y + half * 0.7, x + half * 0.7, y - half * 0.7);
+
   gfx.setDepth(5);
+  gfx.setBlendMode(Phaser.BlendModes.ADD);
   return gfx;
 }

--- a/src/effects.js
+++ b/src/effects.js
@@ -103,3 +103,18 @@ export function evaporateArea(scene, x, y, width, height, color = 0xffffff) {
     });
   }
 }
+
+// Simple cross-shaped electric effect used by electric machines
+export function createElectricCross(scene, x, y, size) {
+  const gfx = scene.add.graphics();
+  const half = size / 2;
+  gfx.lineStyle(2, 0x66ccff, 1);
+  gfx.beginPath();
+  gfx.moveTo(x - half, y);
+  gfx.lineTo(x + half, y);
+  gfx.moveTo(x, y - half);
+  gfx.lineTo(x, y + half);
+  gfx.strokePath();
+  gfx.setDepth(5);
+  return gfx;
+}

--- a/src/game.js
+++ b/src/game.js
@@ -331,11 +331,26 @@ class GameScene extends Phaser.Scene {
       }
 
       if (curTile.chunk.chunk.electricMachines) {
-        const active = curTile.chunk.chunk.electricMachines.some(m => {
-          const dx = Math.abs(m.x - curTile.tx);
-          const dy = Math.abs(m.y - curTile.ty);
-          return dx + dy <= 1 && m.active;
-        });
+        const tileSize = this.mazeManager.tileSize;
+        const heroX = this.heroSprite.x;
+        const heroY = this.heroSprite.y;
+        let active = false;
+        for (const info of this.mazeManager.activeChunks) {
+          if (!info.chunk.electricMachines) continue;
+          const hx = Math.floor((heroX - info.offsetX) / tileSize);
+          const hy = Math.floor((heroY - info.offsetY) / tileSize);
+          if (
+            info.chunk.electricMachines.some(m => {
+              if (!m.active) return false;
+              const dx = Math.abs(m.x - hx);
+              const dy = Math.abs(m.y - hy);
+              return dx + dy <= 1;
+            })
+          ) {
+            active = true;
+            break;
+          }
+        }
         const sameTile =
           active &&
           this.lastElectricTile &&

--- a/src/game.js
+++ b/src/game.js
@@ -345,6 +345,7 @@ class GameScene extends Phaser.Scene {
         if (active && !sameTile) {
           this.cameras.main.flash(100, 0, 0, 0);
           this.cameraManager.shakeSmall();
+          // electric shock uses the same sound as spike damage
           this.sound.play('spike_damage');
           this.hero.oxygen = Math.max(this.hero.oxygen - ELECTRIC_DAMAGE, 0);
           this.events.emit(

--- a/src/game.js
+++ b/src/game.js
@@ -33,7 +33,7 @@ class GameScene extends Phaser.Scene {
     this.bgm = null;
     this.isGameOver = false;
     this.lastSpikeTile = null;
-    this.lastElectricMachine = null;
+    this.lastElectricTile = null;
     this.oxygenLine = null;
     this.oxygenConsole = null;
   }
@@ -47,7 +47,7 @@ class GameScene extends Phaser.Scene {
     this.isMoving = false;
     this.isGameOver = false;
     this.lastSpikeTile = null;
-    this.lastElectricMachine = null;
+    this.lastElectricTile = null;
 
     this.sound.stopAll();
     this.bgm = this.sound.add('bgm', { loop: true });
@@ -331,18 +331,18 @@ class GameScene extends Phaser.Scene {
       }
 
       if (curTile.chunk.chunk.electricMachines) {
-        const em = curTile.chunk.chunk.electricMachines.find(m => {
+        const active = curTile.chunk.chunk.electricMachines.some(m => {
           const dx = Math.abs(m.x - curTile.tx);
           const dy = Math.abs(m.y - curTile.ty);
           return dx + dy <= 1 && m.active;
         });
-        const sameEM =
-          em &&
-          this.lastElectricMachine &&
-          this.lastElectricMachine.chunkIndex === curTile.chunk.index &&
-          this.lastElectricMachine.x === em.x &&
-          this.lastElectricMachine.y === em.y;
-        if (em && !sameEM) {
+        const sameTile =
+          active &&
+          this.lastElectricTile &&
+          this.lastElectricTile.chunkIndex === curTile.chunk.index &&
+          this.lastElectricTile.x === curTile.tx &&
+          this.lastElectricTile.y === curTile.ty;
+        if (active && !sameTile) {
           this.cameras.main.flash(100, 0, 0, 0);
           this.cameraManager.shakeSmall();
           this.sound.play('spike_damage');
@@ -354,13 +354,13 @@ class GameScene extends Phaser.Scene {
           if (this.hero.oxygen <= 0) {
             this.handleGameOver();
           }
-          this.lastElectricMachine = {
+          this.lastElectricTile = {
             chunkIndex: curTile.chunk.index,
-            x: em.x,
-            y: em.y
+            x: curTile.tx,
+            y: curTile.ty
           };
-        } else if (!em) {
-          this.lastElectricMachine = null;
+        } else if (!active) {
+          this.lastElectricTile = null;
         }
       }
 

--- a/src/game.js
+++ b/src/game.js
@@ -15,6 +15,7 @@ import Shield from './shield.js';
 import MeteorField from './meteor_field.js';
 
 const MIDPOINTS = [5, 10, 15, 20, 30, 40, 50];
+const ELECTRIC_DAMAGE = 3;
 
 const VIRTUAL_WIDTH = 480;
 const VIRTUAL_HEIGHT = 270;
@@ -345,7 +346,7 @@ class GameScene extends Phaser.Scene {
           this.cameras.main.flash(100, 0, 0, 0);
           this.cameraManager.shakeSmall();
           this.sound.play('spike_damage');
-          this.hero.oxygen = Math.max(this.hero.oxygen - 3, 0);
+          this.hero.oxygen = Math.max(this.hero.oxygen - ELECTRIC_DAMAGE, 0);
           this.events.emit(
             'updateOxygen',
             this.hero.oxygen / this.hero.maxOxygen

--- a/src/game.js
+++ b/src/game.js
@@ -330,7 +330,7 @@ class GameScene extends Phaser.Scene {
         }
       }
 
-      if (curTile.chunk.chunk.electricMachines) {
+      {
         const tileSize = this.mazeManager.tileSize;
         const heroX = this.heroSprite.x;
         const heroY = this.heroSprite.y;

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -421,7 +421,7 @@ export default class MazeManager {
     if (progress >= 2) {
       this._addSpikes(chunk);
     }
-    if (progress >= 2) {
+    if (progress >= 14) {
       this._addElectricMachine(chunk);
     }
 

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -421,7 +421,7 @@ export default class MazeManager {
     if (progress >= 2) {
       this._addSpikes(chunk);
     }
-    if (progress >= 14) {
+    if (progress >= 2) {
       this._addElectricMachine(chunk);
     }
 


### PR DESCRIPTION
## Summary
- add electric_machine asset registration and creation helper
- draw electric cross effect primitive
- support electric machine placement and updates in MazeManager
- apply damage in GameScene when touching active electric machine

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68842e4772d083338e9173fb965b6da2