### PR TITLE
Add broken sleep pod in starting chunk

### DIFF
--- a/src/characters.js
+++ b/src/characters.js
@@ -10,6 +10,7 @@ const SPRITES = {
   door_open: 'airlock_open.svg',
   treasure: 'treasure.svg',
   sleep_pod: 'sleep_pod.svg',
+  sleep_pod_broken: 'sleep_pod_broken.svg',
   hero_plain: 'hero_plain.svg',
   hero_idle: 'hero.svg',
   hero_walk1: 'hero_walk1.svg',
@@ -122,6 +123,10 @@ function createSleepPod(scene) {
   return scene.add.image(0, 0, 'sleep_pod').setOrigin(0);
 }
 
+function createSleepPodBroken(scene) {
+  return scene.add.image(0, 0, 'sleep_pod_broken').setOrigin(0);
+}
+
 function createMeteor(scene) {
   return scene.add.image(0, 0, 'meteor').setOrigin(0.5);
 }
@@ -159,6 +164,7 @@ export default {
   createOxygenConsole,
   createSpike,
   createSleepPod,
+  createSleepPodBroken,
   createMeteor,
   createMeteorExplosion,
   createHero,

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -39,6 +39,7 @@ export default class MazeManager {
     const chunk = createChunk(this._nextSeed(), size, 'W');
     this._ensureEntrance(chunk);
     this._addOxygenConsole(chunk);
+    this._addBrokenSleepPod(chunk);
     return this.addChunk(chunk, 0, 0);
   }
 
@@ -85,7 +86,15 @@ export default class MazeManager {
         let sprite = null;
         switch (tile) {
           case TILE.WALL:
-            sprite = Characters.createWall(this.scene);
+            if (
+              chunk.brokenPod &&
+              chunk.brokenPod.x === x &&
+              chunk.brokenPod.y === y
+            ) {
+              sprite = Characters.createSleepPodBroken(this.scene);
+            } else {
+              sprite = Characters.createWall(this.scene);
+            }
             break;
           case TILE.SPECIAL:
             sprite = Characters.createOxygenConsole(this.scene);
@@ -555,6 +564,23 @@ export default class MazeManager {
       const spot = candidates[Math.floor(Math.random() * candidates.length)];
       t[spot.y * size + spot.x] = TILE.SPECIAL;
       chunk.oxygenConsole = { x: spot.x, y: spot.y };
+    }
+  }
+
+  _addBrokenSleepPod(chunk) {
+    const size = chunk.size;
+    const t = chunk.tiles;
+    const candidates = [];
+    for (let y = 1; y < size - 1; y++) {
+      for (let x = 1; x < size - 1; x++) {
+        if (t[y * size + x] !== TILE.WALL) continue;
+        if (this._isNearEntranceOrExit(chunk, x, y)) continue;
+        candidates.push({ x, y });
+      }
+    }
+    if (candidates.length) {
+      const spot = candidates[Math.floor(Math.random() * candidates.length)];
+      chunk.brokenPod = { x: spot.x, y: spot.y };
     }
   }
 


### PR DESCRIPTION
## Summary
- add new sleep_pod_broken sprite to characters
- decorate the first chunk with one broken sleep pod wall
- render broken pod walls with collision

## Testing
- `node --check src/characters.js`
- `node --check src/maze_manager.js`
- `node --check src/game.js`


------
https://chatgpt.com/codex/tasks/task_e_68842ffee6e083339b8e00545209173f