### PR TITLE
Add 11x11 restrictions and tweak detours

### DIFF
--- a/src/maze_generator_core.js
+++ b/src/maze_generator_core.js
@@ -151,7 +151,10 @@ export class MazeChunk {
     const size = this.size;
     const tiles = this.tiles;
     const max = Math.max(1, Math.floor(size / 3));
-    const count = rng.nextInt(max) + 1;
+    let count = rng.nextInt(max) + 1;
+    if (size === 11) {
+      count += 2;
+    }
     for (let i = 0; i < count; i++) {
       const x = rng.nextInt(size - 2) + 1;
       const y = rng.nextInt(size - 2) + 1;

--- a/src/maze_table.js
+++ b/src/maze_table.js
@@ -1,7 +1,9 @@
 export const MAZE_TABLE = [
   { stage: 1, sizes: [7] },
-  // From the second chunk onward allow a wider range including 7 again
-  { stage: 2, sizes: [7, 9, 11, 13] }
+  // From the second chunk onward allow 7, 9 and 13 but keep 11 until later
+  { stage: 2, sizes: [7, 9, 13] },
+  // Starting with the seventh chunk, enable 11x11 generation as well
+  { stage: 7, sizes: [7, 9, 11, 13] }
 ];
 
 export function pickMazeConfig(stage) {


### PR DESCRIPTION
## Summary
- adjust maze size table so 11x11 chunks only appear from stage 7
- increase detour count by 2 when generating 11x11 chunks

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6884369b1f58833383ce7fdf1077568c