### PR TITLE
Restrict large chunk sizes and tweak detours

### DIFF
--- a/src/maze_generator_core.js
+++ b/src/maze_generator_core.js
@@ -151,7 +151,12 @@ export class MazeChunk {
     const size = this.size;
     const tiles = this.tiles;
     const max = Math.max(1, Math.floor(size / 3));
-    const count = rng.nextInt(max) + 1;
+    let count = rng.nextInt(max) + 1;
+    if (size >= 13) {
+      count += 2;
+    } else if (size >= 11) {
+      count += 1;
+    }
     for (let i = 0; i < count; i++) {
       const x = rng.nextInt(size - 2) + 1;
       const y = rng.nextInt(size - 2) + 1;

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -35,7 +35,7 @@ export default class MazeManager {
   }
 
   spawnInitial() {
-    const { size } = pickMazeConfig(1);
+    const { size } = pickMazeConfig(1, 0);
     const chunk = createChunk(this._nextSeed(), size, 'W');
     this._ensureEntrance(chunk);
     this._addOxygenConsole(chunk);
@@ -253,7 +253,7 @@ export default class MazeManager {
     const door = fromObj.chunk.door || { dir: 'E', x: fromObj.chunk.size - 1, y: 0 };
     const doorDir = door.dir;
     const entryDir = this._oppositeDir(doorDir);
-    const { size } = pickMazeConfig(progress + 1);
+    const { size } = pickMazeConfig(progress + 1, progress);
     const chunk = createChunk(this._nextSeed(), size, entryDir);
 
     let { offsetX, offsetY } = this._calcOffset(fromObj, chunk.size, doorDir);

--- a/src/maze_table.js
+++ b/src/maze_table.js
@@ -4,9 +4,18 @@ export const MAZE_TABLE = [
   { stage: 2, sizes: [7, 9, 11, 13] }
 ];
 
-export function pickMazeConfig(stage) {
+export function pickMazeConfig(stage, progress = 0) {
   const entry = [...MAZE_TABLE].reverse().find(e => stage >= e.stage) || MAZE_TABLE[0];
-  const sizes = entry.sizes;
+  let sizes = entry.sizes.slice();
+  // Gate larger chunk sizes by progress
+  if (progress < 6) {
+    // Only 7x7 and 9x9 before the 7th chunk
+    sizes = sizes.filter(s => s < 11);
+  } else if (progress < 9) {
+    // Allow up to 11x11 from chunks 7-9
+    sizes = sizes.filter(s => s <= 11);
+  }
+  if (!sizes.length) sizes = entry.sizes;
   const size = sizes[Math.floor(Math.random() * sizes.length)];
   return { size };
 }


### PR DESCRIPTION
## Summary
- gate chunk sizes based on progress so 11x11 appears from chunk 7 and 13x13 from chunk 10
- adjust MazeManager to pass progress to the new config function
- increase random detour count for 11x11 and 13x13 chunks

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6884389f86c483339d8010b1acd99263