### PR TITLE
Handle advanced air tank sound

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -284,7 +284,8 @@ class GameScene extends Phaser.Scene {
       ) {
         curTile.chunk.chunk.airTank.collected = true;
         this.mazeManager.removeAirTank(curTile.chunk);
-        this.sound.play('pick_up');
+        const advanced = curTile.chunk.chunk.airTank.advanced;
+        this.sound.play('pick_up', { rate: advanced ? 0.8 : 1 });
         const amount = curTile.chunk.chunk.airTank.advanced ? 8 : 5;
         this.hero.oxygen = Math.min(
           this.hero.oxygen + amount,


### PR DESCRIPTION
## Summary
- slow down pick_up SFX when advanced air tank is collected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688438aa7e0c8333a0c6be8c11bac7ef