### PR TITLE
Fix broken pod display and corner wall rendering

### DIFF
--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -153,16 +153,16 @@ export default class MazeManager {
               } else {
                 sprite = Characters.createWall(this.scene);
               }
+            } else {
+              sprite = Characters.createWall(this.scene);
+            }
+
             if (
               chunk.brokenPod &&
               chunk.brokenPod.x === x &&
               chunk.brokenPod.y === y
             ) {
               sprite = Characters.createSleepPodBroken(this.scene);
-            }
-              
-            } else {
-              sprite = Characters.createWall(this.scene);
             }
             break;
           }

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -75,20 +75,13 @@ export default class MazeManager {
     for (let y = 0; y < chunk.size; y++) {
       for (let x = 0; x < chunk.size; x++) {
         const tile = chunk.tiles[y * chunk.size + x];
-        const isCorner =
-          (x === 0 && y === 0) ||
-          (x === chunk.size - 1 && y === 0) ||
-          (x === 0 && y === chunk.size - 1) ||
-          (x === chunk.size - 1 && y === chunk.size - 1);
-        if (!isCorner) {
-          const floor = Characters.createFloor(this.scene);
-          floor.setDisplaySize(size, size);
-          floor.setPosition(info.offsetX + x * size, info.offsetY + y * size);
-          // Floors should always render behind other objects
-          floor.setDepth(-1);
-          this.scene.worldLayer.add(floor);
-          info.sprites.push(floor);
-        }
+        const floor = Characters.createFloor(this.scene);
+        floor.setDisplaySize(size, size);
+        floor.setPosition(info.offsetX + x * size, info.offsetY + y * size);
+        // Floors should always render behind other objects
+        floor.setDepth(-1);
+        this.scene.worldLayer.add(floor);
+        info.sprites.push(floor);
 
         let sprite = null;
         switch (tile) {

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -92,12 +92,12 @@ export default class MazeManager {
               t === TILE.DOOR ||
               t === TILE.SILVER_DOOR ||
               t === TILE.AUTO_GATE;
-            const check = (cx, cy) => {
-              if (cx < 0 || cy < 0 || cx >= chunk.size || cy >= chunk.size) {
-                return true;
-              }
-              return isWallLike(chunk.tiles[cy * chunk.size + cx]);
-            };
+            const check = (cx, cy) =>
+              cx >= 0 &&
+              cy >= 0 &&
+              cx < chunk.size &&
+              cy < chunk.size &&
+              isWallLike(chunk.tiles[cy * chunk.size + cx]);
 
             const west = check(x - 1, y);
             const east = check(x + 1, y);

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -209,7 +209,16 @@ export default class MazeManager {
         }
 
         if (sprite) {
-          sprite.setDisplaySize(size, size);
+          if (
+            sprite.texture &&
+            (sprite.texture.key === 'sleep_pod' ||
+              sprite.texture.key === 'sleep_pod_broken')
+          ) {
+            const ratio = sprite.height / sprite.width;
+            sprite.setDisplaySize(size, size * ratio);
+          } else {
+            sprite.setDisplaySize(size, size);
+          }
           const posX = info.offsetX + x * size;
           const posY = info.offsetY + y * size;
           // Center-origin sprites (like wall corners) should be positioned

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -92,12 +92,12 @@ export default class MazeManager {
               t === TILE.DOOR ||
               t === TILE.SILVER_DOOR ||
               t === TILE.AUTO_GATE;
-            const check = (cx, cy) =>
-              cx >= 0 &&
-              cy >= 0 &&
-              cx < chunk.size &&
-              cy < chunk.size &&
-              isWallLike(chunk.tiles[cy * chunk.size + cx]);
+            const check = (cx, cy) => {
+              if (cx < 0 || cy < 0 || cx >= chunk.size || cy >= chunk.size) {
+                return true;
+              }
+              return isWallLike(chunk.tiles[cy * chunk.size + cx]);
+            };
 
             const west = check(x - 1, y);
             const east = check(x + 1, y);


### PR DESCRIPTION
## Summary
- render broken sleep pod regardless of surrounding walls
- avoid oversized corner walls

## Testing
- `node --check src/maze_manager.js`

------
https://chatgpt.com/codex/tasks/task_e_68843dc54a1c83339e5eb2f6f33e994e