### PR TITLE
Stop movement after entering new chunk

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -368,6 +368,9 @@ class GameScene extends Phaser.Scene {
             curTile.chunk,
             this.heroSprite
           );
+          if (this.inputBuffer && this.inputBuffer.clear) {
+            this.inputBuffer.clear();
+          }
           if (gameState.clearedMazes === 1 && !this.oxygenTimer) {
             this.startOxygenTimer();
           }

--- a/src/input_buffer.js
+++ b/src/input_buffer.js
@@ -102,4 +102,10 @@ export default class InputBuffer {
       this.holdOrder.unshift(dir);
     }
   }
+
+  clear() {
+    this.buffer = [];
+    this.holdKeys = {};
+    this.holdOrder = [];
+  }
 }


### PR DESCRIPTION
## Summary
- add `clear()` method to InputBuffer for clearing held keys and buffer
- clear the input buffer when spawning a new maze chunk so movement halts at the entrance

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6884429c6abc83339f15f53b518c119e