### PR TITLE
Stop moving on first tile after door

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -98,6 +98,9 @@ class GameScene extends Phaser.Scene {
     this.mazeManager.events.on('spawn-next', data => {
       newChunkTransition(this, data.doorDir, data.doorWorldX, data.doorWorldY);
       this.sound.play('chunk_generate_2');
+      if (this.inputBuffer && this.inputBuffer.reset) {
+        this.inputBuffer.reset();
+      }
       if (data.info && data.info.index === 1) {
         this.bgm.play();
         this.destroyIntroText();

--- a/src/input_buffer.js
+++ b/src/input_buffer.js
@@ -102,4 +102,10 @@ export default class InputBuffer {
       this.holdOrder.unshift(dir);
     }
   }
+
+  reset() {
+    this.buffer.length = 0;
+    this.holdOrder.length = 0;
+    this.holdKeys = {};
+  }
 }


### PR DESCRIPTION
## Summary
- add `reset()` method to `InputBuffer`
- clear input buffer when entering a new chunk so held keys don't auto-move

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688446abe5248333bcc4c74ced09137e