### PR TITLE
Fix hero stops after entering new chunk

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -34,6 +34,7 @@ class GameScene extends Phaser.Scene {
     this.lastSpikeTile = null;
     this.oxygenLine = null;
     this.oxygenConsole = null;
+    this.stopTile = null;
   }
 
   preload() {
@@ -167,6 +168,21 @@ class GameScene extends Phaser.Scene {
 
   update() {
     const delta = this.game.loop.delta;
+
+    const tileHere = this.mazeManager.worldToTile(
+      this.heroSprite.x,
+      this.heroSprite.y
+    );
+    if (
+      this.stopTile &&
+      tileHere &&
+      tileHere.chunk.index === this.stopTile.chunkIndex &&
+      tileHere.tx === this.stopTile.tx &&
+      tileHere.ty === this.stopTile.ty
+    ) {
+      this.inputBuffer.clear();
+      this.stopTile = null;
+    }
 
     if (!this.isMoving && !this.isGameOver) {
       const entry = this.inputBuffer.consume();
@@ -368,7 +384,29 @@ class GameScene extends Phaser.Scene {
             curTile.chunk,
             this.heroSprite
           );
-          this.inputBuffer.clear();
+          // Stop the hero one tile inside the new chunk on first entry
+          let sx = nextInfo.chunk.entrance.x;
+          let sy = nextInfo.chunk.entrance.y;
+          switch (nextInfo.chunk.entry) {
+            case 'N':
+              sy += 1;
+              break;
+            case 'S':
+              sy -= 1;
+              break;
+            case 'W':
+              sx += 1;
+              break;
+            case 'E':
+            default:
+              sx -= 1;
+              break;
+          }
+          this.stopTile = {
+            chunkIndex: nextInfo.index,
+            tx: sx,
+            ty: sy
+          };
           if (gameState.clearedMazes === 1 && !this.oxygenTimer) {
             this.startOxygenTimer();
           }

--- a/src/game.js
+++ b/src/game.js
@@ -368,6 +368,7 @@ class GameScene extends Phaser.Scene {
             curTile.chunk,
             this.heroSprite
           );
+          this.inputBuffer.clear();
           if (gameState.clearedMazes === 1 && !this.oxygenTimer) {
             this.startOxygenTimer();
           }

--- a/src/input_buffer.js
+++ b/src/input_buffer.js
@@ -102,4 +102,10 @@ export default class InputBuffer {
       this.holdOrder.unshift(dir);
     }
   }
+
+  clear() {
+    this.buffer = [];
+    this.holdKeys = {};
+    this.holdOrder = [];
+  }
 }


### PR DESCRIPTION
## Summary
- add `clear` method to `InputBuffer` to reset input state
- clear input buffer when spawning next chunk to halt movement

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884484830e08333a8906b8497ef1b67