### PR TITLE
Fix broken sleep pod display

### DIFF
--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -153,16 +153,16 @@ export default class MazeManager {
               } else {
                 sprite = Characters.createWall(this.scene);
               }
+            } else {
+              sprite = Characters.createWall(this.scene);
+            }
+
             if (
               chunk.brokenPod &&
               chunk.brokenPod.x === x &&
               chunk.brokenPod.y === y
             ) {
               sprite = Characters.createSleepPodBroken(this.scene);
-            }
-              
-            } else {
-              sprite = Characters.createWall(this.scene);
             }
             break;
           }


### PR DESCRIPTION
## Summary
- ensure broken sleep pod sprite is used regardless of surrounding wall configuration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688449d21c9c8333b6f6628a08daf13f