### PR TITLE
Add floor decal variations

### DIFF
--- a/assets/images/floor_crack1.svg
+++ b/assets/images/floor_crack1.svg
@@ -1,3 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
-  <path d="M2 16 l8 -4 l4 4 l4 -8 l4 4 l8 -4" stroke="#333" stroke-width="2" fill="none" />
+  <g stroke="#a6a7ab" stroke-width="1" fill="none" stroke-linecap="round">
+    <path d="M2 18 l6 -3 l2 3 l5 -7 l3 5 l5 -2 l6 -6" />
+    <path d="M10 15 l-2 -4" />
+    <path d="M17 13 l3 3" />
+    <path d="M22 15 l2 -5" />
+  </g>
 </svg>

--- a/assets/images/floor_crack1.svg
+++ b/assets/images/floor_crack1.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <path d="M2 16 l8 -4 l4 4 l4 -8 l4 4 l8 -4" stroke="#333" stroke-width="2" fill="none" />
+</svg>

--- a/assets/images/floor_crack2.svg
+++ b/assets/images/floor_crack2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <path d="M16 4 l0 6 m0 12 l0 6 m-12 -12 l6 0 m12 0 l6 0 m-8 -8 l-4 4 m0 0 l-4 -4 m8 8 l-4 4 m0 0 l4 4" stroke="#333" stroke-width="2" fill="none" />
+</svg>

--- a/assets/images/floor_crack2.svg
+++ b/assets/images/floor_crack2.svg
@@ -1,3 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
-  <path d="M16 4 l0 6 m0 12 l0 6 m-12 -12 l6 0 m12 0 l6 0 m-8 -8 l-4 4 m0 0 l-4 -4 m8 8 l-4 4 m0 0 l4 4" stroke="#333" stroke-width="2" fill="none" />
+  <g stroke="#b3b4b7" stroke-width="1" fill="none" stroke-linecap="round">
+    <path d="M4 6 l5 7 l-1 5 l6 -3 l3 3 l5 -9" />
+    <path d="M10 11 l-5 2" />
+    <path d="M15 13 l3 -4" />
+    <path d="M20 9 l2 5" />
+    <path d="M22 14 l6 -2" />
+  </g>
 </svg>

--- a/assets/images/floor_dirt1.svg
+++ b/assets/images/floor_dirt1.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <g fill="#666">
+    <ellipse cx="12" cy="20" rx="5" ry="3" />
+    <ellipse cx="20" cy="12" rx="4" ry="2" />
+  </g>
+</svg>

--- a/assets/images/floor_dirt1.svg
+++ b/assets/images/floor_dirt1.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
-  <g fill="#666">
-    <ellipse cx="12" cy="20" rx="5" ry="3" />
-    <ellipse cx="20" cy="12" rx="4" ry="2" />
+  <g fill="#b9babd">
+    <path d="M9 21c2-2 7-2 9 0c1 1 1 2 -2 3c-5 1 -8 0 -7-3z" />
+    <path d="M19 12c1-2 4-3 5-1c1 2 -1 3 -3 4c-2 0 -3-1 -2-3z" />
   </g>
 </svg>

--- a/assets/images/floor_dirt2.svg
+++ b/assets/images/floor_dirt2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <g fill="#555">
+    <ellipse cx="10" cy="10" rx="3" ry="2" />
+    <ellipse cx="16" cy="18" rx="6" ry="3" />
+    <ellipse cx="22" cy="12" rx="2" ry="1" />
+  </g>
+</svg>

--- a/assets/images/floor_dirt2.svg
+++ b/assets/images/floor_dirt2.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
-  <g fill="#555">
-    <ellipse cx="10" cy="10" rx="3" ry="2" />
-    <ellipse cx="16" cy="18" rx="6" ry="3" />
-    <ellipse cx="22" cy="12" rx="2" ry="1" />
+  <g fill="#b0b0b0">
+    <path d="M13 23c3-1 5 0 5 2c0 2-4 3-6 1c-1-1 0-2 1-3z" />
+    <path d="M8 11c1-2 4-1 4 1c0 1-2 2-3 1c-1-1 -1-2 -1-2z" />
+    <path d="M20 15c2-1 5 1 4 3c-1 2-4 1-5 0c-1-1 0-2 1-3z" />
   </g>
 </svg>

--- a/assets/images/floor_scratch1.svg
+++ b/assets/images/floor_scratch1.svg
@@ -1,4 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
-  <path d="M4 20 l8 -6" stroke="#444" stroke-width="2" />
-  <path d="M10 22 l10 -8" stroke="#444" stroke-width="2" />
+  <g stroke="#a1a1a1" stroke-width="1" stroke-linecap="round">
+    <path d="M4 21 l10 -6" />
+    <path d="M8 23 l12 -7" />
+    <path d="M12 25 l10 -6" />
+  </g>
 </svg>

--- a/assets/images/floor_scratch1.svg
+++ b/assets/images/floor_scratch1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <path d="M4 20 l8 -6" stroke="#444" stroke-width="2" />
+  <path d="M10 22 l10 -8" stroke="#444" stroke-width="2" />
+</svg>

--- a/assets/images/floor_scratch2.svg
+++ b/assets/images/floor_scratch2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <path d="M6 10 l20 0" stroke="#444" stroke-width="1" />
+  <path d="M4 14 l18 0" stroke="#444" stroke-width="1" />
+  <path d="M8 18 l16 0" stroke="#444" stroke-width="1" />
+</svg>

--- a/assets/images/floor_scratch2.svg
+++ b/assets/images/floor_scratch2.svg
@@ -1,5 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
-  <path d="M6 10 l20 0" stroke="#444" stroke-width="1" />
-  <path d="M4 14 l18 0" stroke="#444" stroke-width="1" />
-  <path d="M8 18 l16 0" stroke="#444" stroke-width="1" />
+  <g stroke="#ababab" stroke-width="1" stroke-linecap="round">
+    <path d="M6 12 l18 0" />
+    <path d="M4 16 l16 0" />
+    <path d="M8 20 l14 0" />
+  </g>
 </svg>

--- a/src/characters.js
+++ b/src/characters.js
@@ -33,7 +33,13 @@ const SPRITES = {
   meteor_explosion2: 'meteor_explosion2.svg',
   meteor_explosion3: 'meteor_explosion3.svg',
   wall_corner: 'wall_corner.svg',
-  wall_end: 'wall_end.svg'
+  wall_end: 'wall_end.svg',
+  floor_crack1: 'floor_crack1.svg',
+  floor_crack2: 'floor_crack2.svg',
+  floor_dirt1: 'floor_dirt1.svg',
+  floor_dirt2: 'floor_dirt2.svg',
+  floor_scratch1: 'floor_scratch1.svg',
+  floor_scratch2: 'floor_scratch2.svg'
 };
 
 const canvases = {};
@@ -110,6 +116,10 @@ function createAutoGateClosed(scene) {
 
 function createDoorOpen(scene) {
   return scene.add.image(0, 0, 'door_open').setOrigin(0);
+}
+
+function createFloorDecal(scene, key) {
+  return scene.add.image(0, 0, key).setOrigin(0.5);
 }
 
 function createTreasure(scene) {
@@ -189,5 +199,6 @@ export default {
   createMeteorExplosion,
   createHero,
   createHeroPlain,
-  createArrow
+  createArrow,
+  createFloorDecal
 };

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -3,6 +3,16 @@ import Characters from './characters.js';
 import { pickMazeConfig } from './maze_table.js';
 import { evaporateChunk } from './effects.js';
 
+const DECAL_KEYS = [
+  'floor_crack1',
+  'floor_crack2',
+  'floor_dirt1',
+  'floor_dirt2',
+  'floor_scratch1',
+  'floor_scratch2'
+];
+const DECAL_CHANCE = 0.1;
+
 export default class MazeManager {
   constructor(scene) {
     this.scene = scene;
@@ -72,6 +82,9 @@ export default class MazeManager {
 
   renderChunk(chunk, info) {
     const size = this.tileSize;
+    const decalMap = Array.from({ length: chunk.size }, () =>
+      Array(chunk.size).fill(false)
+    );
     for (let y = 0; y < chunk.size; y++) {
       for (let x = 0; x < chunk.size; x++) {
         const tile = chunk.tiles[y * chunk.size + x];
@@ -88,6 +101,10 @@ export default class MazeManager {
           floor.setDepth(-1);
           this.scene.worldLayer.add(floor);
           info.sprites.push(floor);
+
+          if (tile === TILE.FLOOR) {
+            this._maybeAddFloorDecal(info, decalMap, x, y);
+          }
         }
 
         let sprite = null;
@@ -691,6 +708,43 @@ export default class MazeManager {
       }
     }
     chunk.spikes = spikes;
+  }
+
+  _maybeAddFloorDecal(info, decalMap, x, y) {
+    if (Math.random() >= DECAL_CHANCE) return;
+    if (decalMap[y][x]) return;
+    for (let dy = -1; dy <= 1; dy++) {
+      for (let dx = -1; dx <= 1; dx++) {
+        if (dx === 0 && dy === 0) continue;
+        const nx = x + dx;
+        const ny = y + dy;
+        if (ny >= 0 && ny < decalMap.length && nx >= 0 && nx < decalMap.length) {
+          if (decalMap[ny][nx]) return;
+        }
+      }
+    }
+
+    const key = DECAL_KEYS[Math.floor(Math.random() * DECAL_KEYS.length)];
+    const decal = Characters.createFloorDecal(this.scene, key);
+    decal.setDisplaySize(this.tileSize, this.tileSize);
+    const baseX = info.offsetX + x * this.tileSize;
+    const baseY = info.offsetY + y * this.tileSize;
+    const jitter = this.tileSize * 0.25;
+    let posX = baseX + jitter * (Math.random() - 0.5);
+    let posY = baseY + jitter * (Math.random() - 0.5);
+    if (Math.random() < 0.25) {
+      if (Math.random() < 0.5) {
+        posX += this.tileSize * (Math.random() < 0.5 ? -0.5 : 0.5);
+      } else {
+        posY += this.tileSize * (Math.random() < 0.5 ? -0.5 : 0.5);
+      }
+    }
+    decal.setPosition(posX + this.tileSize / 2, posY + this.tileSize / 2);
+    decal.setAngle(Math.floor(Math.random() * 360));
+    decal.setDepth(-0.5);
+    this.scene.worldLayer.add(decal);
+    info.sprites.push(decal);
+    decalMap[y][x] = true;
   }
 
   openDoor(info) {


### PR DESCRIPTION
## Summary
- add simple floor decals for cracks, dirt and scratches, two each

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68844baca33883338e00248b82af9cd3