### PR TITLE
Fix duplicate wall sprite when rendering broken sleep pod

### DIFF
--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -121,6 +121,17 @@ export default class MazeManager {
               info.electricMachineSprites.push(machine);
               break;
             }
+            // Display a broken sleep pod instead of a wall if this position
+            // is marked as such. This must be done before creating any wall
+            // sprites to avoid leaving unused wall graphics in the scene.
+            if (
+              chunk.brokenPod &&
+              chunk.brokenPod.x === x &&
+              chunk.brokenPod.y === y
+            ) {
+              sprite = Characters.createSleepPodBroken(this.scene);
+              break;
+            }
             // Count surrounding wall-like tiles (including doors) in all 8 directions
             const isWallLike = t =>
               t === TILE.WALL ||
@@ -183,14 +194,6 @@ export default class MazeManager {
               }
             } else {
               sprite = Characters.createWall(this.scene);
-            }
-
-            if (
-              chunk.brokenPod &&
-              chunk.brokenPod.x === x &&
-              chunk.brokenPod.y === y
-            ) {
-              sprite = Characters.createSleepPodBroken(this.scene);
             }
             break;
           }


### PR DESCRIPTION
## Summary
- fix bug where a wall sprite was created before a broken sleep pod

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884714b936083338d12914155cf7252