### PR TITLE
Increase midpoint display duration

### DIFF
--- a/src/ui_scene.js
+++ b/src/ui_scene.js
@@ -166,7 +166,7 @@ export default class UIScene extends Phaser.Scene {
       targets: text,
       scale: 2,
       alpha: 0,
-      duration: 1000,
+      duration: 2000,
       ease: 'Quad.easeOut',
       onComplete: () => text.destroy()
     });


### PR DESCRIPTION
## Summary
- extend the midpoint chunk count text fade-out duration from 1 second to 2 seconds

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6884724990888333978148719c5df953