### PR TITLE
Implement rest point chunk with oxygen refill

### DIFF
--- a/src/characters.js
+++ b/src/characters.js
@@ -11,6 +11,7 @@ const SPRITES = {
   treasure: 'treasure.svg',
   sleep_pod: 'sleep_pod.svg',
   sleep_pod_broken: 'sleep_pod_broken.svg',
+  sleep_pod_with_hero: 'sleep_pod_with_hero.svg',
   hero_plain: 'hero_plain.svg',
   hero_idle: 'hero.svg',
   hero_walk1: 'hero_walk1.svg',
@@ -159,6 +160,10 @@ function createSleepPodBroken(scene) {
   return scene.add.image(0, 0, 'sleep_pod_broken').setOrigin(0);
 }
 
+function createSleepPodWithHero(scene) {
+  return scene.add.image(0, 0, 'sleep_pod_with_hero').setOrigin(0);
+}
+
 function createMeteor(scene) {
   return scene.add.image(0, 0, 'meteor').setOrigin(0.5);
 }
@@ -201,6 +206,7 @@ export default {
   createElectricMachine,
   createSleepPod,
   createSleepPodBroken,
+  createSleepPodWithHero,
   createMeteor,
   createMeteorExplosion,
   createHero,

--- a/src/game.js
+++ b/src/game.js
@@ -111,6 +111,10 @@ class GameScene extends Phaser.Scene {
           this.oxygenLine = this.add.graphics();
           this.worldLayer.add(this.oxygenLine);
         }
+        if (this.bgm && this.bgm.isPlaying) {
+          this.bgm.stop();
+        }
+        this.sound.play('pick_up');
         this.hero.oxygen = this.hero.maxOxygen;
         this.events.emit('updateOxygen', 1);
         if (this.oxygenTimer) {

--- a/src/game.js
+++ b/src/game.js
@@ -101,31 +101,48 @@ class GameScene extends Phaser.Scene {
     this.mazeManager.events.on('spawn-next', data => {
       newChunkTransition(this, data.doorDir, data.doorWorldX, data.doorWorldY);
       this.sound.play('chunk_generate_2');
+
+      if (data.info && data.info.restPoint) {
+        const size = this.mazeManager.tileSize;
+        const cx = data.info.offsetX + data.info.oxygenPosition.x * size + size / 2;
+        const cy = data.info.offsetY + data.info.oxygenPosition.y * size + size / 2;
+        this.oxygenConsole = { x: cx, y: cy };
+        if (!this.oxygenLine) {
+          this.oxygenLine = this.add.graphics();
+          this.worldLayer.add(this.oxygenLine);
+        }
+        this.hero.oxygen = this.hero.maxOxygen;
+        this.events.emit('updateOxygen', 1);
+        if (this.oxygenTimer) {
+          this.oxygenTimer.remove();
+          this.oxygenTimer = null;
+        }
+      } else if (this.oxygenLine) {
+        const hx = this.heroSprite.x;
+        const hy = this.heroSprite.y;
+        const cx = this.oxygenConsole.x;
+        const cy = this.oxygenConsole.y;
+        const points = computeTetherPoints(cx, cy, hx, hy, this.mazeManager.tileSize, 5);
+        points.forEach((p, i) => {
+          if (i === 0) return;
+          this.time.delayedCall(i * 40, () => {
+            evaporateArea(this, p.x - 4, p.y - 4, 8, 8, 0xffffff);
+          });
+        });
+        this.tweens.add({
+          targets: this.oxygenLine,
+          alpha: 0,
+          duration: 200,
+          onComplete: () => {
+            this.oxygenLine.destroy();
+            this.oxygenLine = null;
+          }
+        });
+      }
+
       if (data.info && data.info.index === 1) {
         this.bgm.play();
         this.destroyIntroText();
-        if (this.oxygenLine) {
-          const hx = this.heroSprite.x;
-          const hy = this.heroSprite.y;
-          const cx = this.oxygenConsole.x;
-          const cy = this.oxygenConsole.y;
-          const points = computeTetherPoints(cx, cy, hx, hy, this.mazeManager.tileSize, 5);
-          points.forEach((p, i) => {
-            if (i === 0) return;
-            this.time.delayedCall(i * 40, () => {
-              evaporateArea(this, p.x - 4, p.y - 4, 8, 8, 0xffffff);
-            });
-          });
-          this.tweens.add({
-            targets: this.oxygenLine,
-            alpha: 0,
-            duration: 200,
-            onComplete: () => {
-              this.oxygenLine.destroy();
-              this.oxygenLine = null;
-            }
-          });
-        }
       }
     });
 
@@ -448,7 +465,10 @@ class GameScene extends Phaser.Scene {
             tx: sx,
             ty: sy
           };
-          if (gameState.clearedMazes === 1 && !this.oxygenTimer) {
+          if (
+            (gameState.clearedMazes === 1 || gameState.clearedMazes === 9) &&
+            !this.oxygenTimer
+          ) {
             this.startOxygenTimer();
           }
         } else {


### PR DESCRIPTION
## Summary
- add logic in `MazeManager.spawnNext` to generate a special rest point on the 9th chunk
- connect hero to the new oxygen console and refill oxygen when entering the rest point
- stop oxygen depletion while resting and resume when leaving

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688476ae24108333bde1eaa98dd0f675