### PR TITLE
Enhance electric machine spawn logic

### DIFF
--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -801,8 +801,9 @@ export default class MazeManager {
     if (progress >= 15) {
       chance = progress === 15 ? 1 : 0.6;
     }
-    if (candidates.length && Math.random() < chance) {
-      const spot = candidates[Math.floor(Math.random() * candidates.length)];
+    const addMachine = () => {
+      const idx = Math.floor(Math.random() * candidates.length);
+      const spot = candidates.splice(idx, 1)[0];
       chunk.electricMachines.push({
         x: spot.x,
         y: spot.y,
@@ -811,6 +812,19 @@ export default class MazeManager {
         lastEffect: -Infinity,
         lastLeak: -Infinity
       });
+    };
+
+    if (candidates.length && Math.random() < chance) {
+      addMachine();
+    }
+
+    if (progress >= 20 && chunk.electricMachines.length && candidates.length) {
+      if (Math.random() < 0.8 && candidates.length) {
+        addMachine();
+      }
+      if (Math.random() < 0.1 && candidates.length) {
+        addMachine();
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- add helper to spawn electric machines
- allow extra electric machines to appear from chunk 20 onward

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688478427da48333aa01a04c39cc9913