### PR TITLE
Increase floor decal frequency

### DIFF
--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -11,7 +11,7 @@ const DECAL_KEYS = [
   'floor_scratch1',
   'floor_scratch2'
 ];
-const DECAL_CHANCE = 0.1;
+const DECAL_CHANCE = 0.15;
 
 export default class MazeManager {
   constructor(scene) {


### PR DESCRIPTION
## Summary
- tweak maze_manager decal chance constant to 0.15

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68847fa741f08333baeef5efce1a5f2b