### PR TITLE
Shift rest points to chunks 15 and 30

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -475,8 +475,8 @@ class GameScene extends Phaser.Scene {
           };
           if (
             (gameState.clearedMazes === 1 ||
-              gameState.clearedMazes === 14 ||
-              gameState.clearedMazes === 29) &&
+              gameState.clearedMazes === 15 ||
+              gameState.clearedMazes === 30) &&
             !this.oxygenTimer
           ) {
             this.startOxygenTimer();

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -441,14 +441,14 @@ export default class MazeManager {
     const doorDir = door.dir;
     const entryDir = this._oppositeDir(doorDir);
 
-    const isRestPoint = progress === 13 || progress === 28;
+    const isRestPoint = progress === 14 || progress === 29;
 
     let chunk;
     if (isRestPoint) {
       chunk = createChunk(this._nextSeed(), 7, entryDir);
       this._ensureEntrance(chunk);
       this._addOxygenConsole(chunk);
-      if (progress === 28) {
+      if (progress === 29) {
         this._addBrokenSleepPod(chunk);
       }
       this._addSleepPodsWithHero(chunk, 5);


### PR DESCRIPTION
## Summary
- adjust rest point spawning logic to use chunk numbers 15 and 30
- update oxygen timer logic for the new rest points

## Testing
- `node --check src/maze_manager.js`
- `node --check src/game.js`


------
https://chatgpt.com/codex/tasks/task_e_6884848669a88333a1be1d8610464284