### PR TITLE
Fix rest chunk sleep pod placement

### DIFF
--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -790,8 +790,15 @@ export default class MazeManager {
     const size = chunk.size;
     const t = chunk.tiles;
     const candidates = [];
-    for (let y = 1; y < size - 1; y++) {
-      for (let x = 1; x < size - 1; x++) {
+    for (let y = 0; y < size; y++) {
+      for (let x = 0; x < size; x++) {
+        if (
+          (x === 0 && y === 0) ||
+          (x === 0 && y === size - 1) ||
+          (x === size - 1 && y === 0) ||
+          (x === size - 1 && y === size - 1)
+        )
+          continue;
         if (t[y * size + x] !== TILE.WALL) continue;
         if (this._isNearEntranceOrExit(chunk, x, y)) continue;
         candidates.push({ x, y });
@@ -808,8 +815,15 @@ export default class MazeManager {
     const size = chunk.size;
     const t = chunk.tiles;
     const candidates = [];
-    for (let y = 1; y < size - 1; y++) {
-      for (let x = 1; x < size - 1; x++) {
+    for (let y = 0; y < size; y++) {
+      for (let x = 0; x < size; x++) {
+        if (
+          (x === 0 && y === 0) ||
+          (x === 0 && y === size - 1) ||
+          (x === size - 1 && y === 0) ||
+          (x === size - 1 && y === size - 1)
+        )
+          continue;
         if (t[y * size + x] !== TILE.WALL) continue;
         if (this._isNearEntranceOrExit(chunk, x, y)) continue;
         candidates.push({ x, y });
@@ -825,8 +839,15 @@ export default class MazeManager {
     const size = chunk.size;
     const t = chunk.tiles;
     const candidates = [];
-    for (let y = 1; y < size - 1; y++) {
-      for (let x = 1; x < size - 1; x++) {
+    for (let y = 0; y < size; y++) {
+      for (let x = 0; x < size; x++) {
+        if (
+          (x === 0 && y === 0) ||
+          (x === 0 && y === size - 1) ||
+          (x === size - 1 && y === 0) ||
+          (x === size - 1 && y === size - 1)
+        )
+          continue;
         if (t[y * size + x] !== TILE.WALL) continue;
         if (this._isNearEntranceOrExit(chunk, x, y)) continue;
         if (chunk.oxygenConsole && chunk.oxygenConsole.x === x && chunk.oxygenConsole.y === y)


### PR DESCRIPTION
## Summary
- allow broken sleep pods and hero sleep pods to spawn on outer wall tiles so the 30th chunk rest point shows `sleep_pod_with_hero.svg` and a broken pod

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68848ffe0ff88333912bc0c9ed8095c6