### PR TITLE
Add rival character SVGs

### DIFF
--- a/assets/images/rival_back_walk1.svg
+++ b/assets/images/rival_back_walk1.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffb3b3"/>
+      <stop offset="100%" stop-color="#d95757"/>
+    </linearGradient>
+      </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+        <!-- Legs -->
+  <ellipse cx="11" cy="34" rx="4" ry="2" fill="#ff8080"/>
+  <ellipse cx="21" cy="34" rx="4" ry="2" fill="#ff8080"/>
+      <!-- Head -->
+  <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+  <ellipse cx="8" cy="14" rx="4" ry="2" fill="#ff8080"/>
+  <ellipse cx="24" cy="14" rx="4" ry="2" fill="#ff8080"/>
+  <path d="M10 12 L22 12" stroke="#aa3939" stroke-width="2"/>
+              </svg>

--- a/assets/images/rival_back_walk2.svg
+++ b/assets/images/rival_back_walk2.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffb3b3"/>
+      <stop offset="100%" stop-color="#d95757"/>
+    </linearGradient>
+      </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+        <!-- Legs -->
+  <ellipse cx="11" cy="32" rx="4" ry="2" fill="#ff8080"/>
+  <ellipse cx="21" cy="36" rx="4" ry="2" fill="#ff8080"/>
+      <!-- Head -->
+  <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+  <ellipse cx="8" cy="13" rx="4" ry="2" fill="#ff8080"/>
+  <ellipse cx="24" cy="15" rx="4" ry="2" fill="#ff8080"/>
+  <path d="M10 12 L22 12" stroke="#aa3939" stroke-width="2"/>
+              </svg>

--- a/assets/images/rival_back_walk3.svg
+++ b/assets/images/rival_back_walk3.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffb3b3"/>
+      <stop offset="100%" stop-color="#d95757"/>
+    </linearGradient>
+      </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+        <!-- Legs -->
+  <ellipse cx="11" cy="36" rx="4" ry="2" fill="#ff8080"/>
+  <ellipse cx="21" cy="32" rx="4" ry="2" fill="#ff8080"/>
+      <!-- Head -->
+  <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+  <ellipse cx="8" cy="15" rx="4" ry="2" fill="#ff8080"/>
+  <ellipse cx="24" cy="13" rx="4" ry="2" fill="#ff8080"/>
+  <path d="M10 12 L22 12" stroke="#aa3939" stroke-width="2"/>
+              </svg>

--- a/assets/images/rival_right_walk1.svg
+++ b/assets/images/rival_right_walk1.svg
@@ -17,6 +17,7 @@
   <ellipse cx="24" cy="14" rx="4" ry="2" fill="#ff8080"/>
   <circle cx="22" cy="6" r="4" fill="#ffffff"/>
   <circle cx="22" cy="6" r="2" fill="#000000"/>
-  <path d="M14 12 Q18 16 22 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <!-- Angry mouth -->
+  <path d="M14 12 Q18 8 22 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
   <path d="M10 11 C12 9, 24 9, 26 11" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
   </svg>

--- a/assets/images/rival_right_walk1.svg
+++ b/assets/images/rival_right_walk1.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffb3b3"/>
+      <stop offset="100%" stop-color="#d95757"/>
+    </linearGradient>
+      </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+      <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <rect x="15" y="26" width="2" height="3" fill="#808080"/>
+  <!-- Legs -->
+  <ellipse cx="11" cy="34" rx="4" ry="2" fill="#ff8080"/>
+  <ellipse cx="21" cy="34" rx="4" ry="2" fill="#ff8080"/>
+      <!-- Head -->
+  <ellipse cx="18" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+  <ellipse cx="24" cy="14" rx="4" ry="2" fill="#ff8080"/>
+  <circle cx="22" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="22" cy="6" r="2" fill="#000000"/>
+  <path d="M14 12 Q18 16 22 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M10 11 C12 9, 24 9, 26 11" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </svg>

--- a/assets/images/rival_right_walk2.svg
+++ b/assets/images/rival_right_walk2.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffb3b3"/>
+      <stop offset="100%" stop-color="#d95757"/>
+    </linearGradient>
+      </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+      <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <rect x="15" y="26" width="2" height="3" fill="#808080"/>
+  <!-- Legs -->
+  <ellipse cx="11" cy="32" rx="4" ry="2" fill="#ff8080"/>
+  <ellipse cx="21" cy="36" rx="4" ry="2" fill="#ff8080"/>
+      <!-- Head -->
+  <ellipse cx="18" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+  <ellipse cx="24" cy="15" rx="4" ry="2" fill="#ff8080"/>
+  <circle cx="22" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="22" cy="6" r="2" fill="#000000"/>
+  <path d="M14 12 Q18 16 22 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M10 11 C12 9, 24 9, 26 11" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </svg>

--- a/assets/images/rival_right_walk2.svg
+++ b/assets/images/rival_right_walk2.svg
@@ -17,6 +17,7 @@
   <ellipse cx="24" cy="15" rx="4" ry="2" fill="#ff8080"/>
   <circle cx="22" cy="6" r="4" fill="#ffffff"/>
   <circle cx="22" cy="6" r="2" fill="#000000"/>
-  <path d="M14 12 Q18 16 22 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <!-- Angry mouth -->
+  <path d="M14 12 Q18 8 22 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
   <path d="M10 11 C12 9, 24 9, 26 11" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
   </svg>

--- a/assets/images/rival_right_walk3.svg
+++ b/assets/images/rival_right_walk3.svg
@@ -17,6 +17,7 @@
   <ellipse cx="24" cy="13" rx="4" ry="2" fill="#ff8080"/>
   <circle cx="22" cy="6" r="4" fill="#ffffff"/>
   <circle cx="22" cy="6" r="2" fill="#000000"/>
-  <path d="M14 12 Q18 16 22 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <!-- Angry mouth -->
+  <path d="M14 12 Q18 8 22 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
   <path d="M10 11 C12 9, 24 9, 26 11" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
   </svg>

--- a/assets/images/rival_right_walk3.svg
+++ b/assets/images/rival_right_walk3.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffb3b3"/>
+      <stop offset="100%" stop-color="#d95757"/>
+    </linearGradient>
+      </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+      <rect x="10" y="26" width="12" height="3" fill="#c0c0c0"/>
+  <rect x="15" y="26" width="2" height="3" fill="#808080"/>
+  <!-- Legs -->
+  <ellipse cx="11" cy="36" rx="4" ry="2" fill="#ff8080"/>
+  <ellipse cx="21" cy="32" rx="4" ry="2" fill="#ff8080"/>
+      <!-- Head -->
+  <ellipse cx="18" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+  <ellipse cx="24" cy="13" rx="4" ry="2" fill="#ff8080"/>
+  <circle cx="22" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="22" cy="6" r="2" fill="#000000"/>
+  <path d="M14 12 Q18 16 22 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M10 11 C12 9, 24 9, 26 11" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </svg>

--- a/assets/images/rival_walk1.svg
+++ b/assets/images/rival_walk1.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffb3b3"/>
+      <stop offset="100%" stop-color="#d95757"/>
+    </linearGradient>
+  </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+        <!-- Legs -->
+  <ellipse cx="11" cy="34" rx="4" ry="2" fill="#ff8080"/>
+  <ellipse cx="21" cy="34" rx="4" ry="2" fill="#ff8080"/>
+    <!-- Head -->
+  <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+  <ellipse cx="8" cy="14" rx="4" ry="2" fill="#ff8080"/>
+  <ellipse cx="24" cy="14" rx="4" ry="2" fill="#ff8080"/>
+  <circle cx="10" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="22" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="10" cy="6" r="2" fill="#000000"/>
+  <circle cx="22" cy="6" r="2" fill="#000000"/>
+  <path d="M12 12 Q16 16 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M8 10 C10 8, 22 8, 24 10" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </svg>

--- a/assets/images/rival_walk1.svg
+++ b/assets/images/rival_walk1.svg
@@ -18,6 +18,7 @@
   <circle cx="22" cy="6" r="4" fill="#ffffff"/>
   <circle cx="10" cy="6" r="2" fill="#000000"/>
   <circle cx="22" cy="6" r="2" fill="#000000"/>
-  <path d="M12 12 Q16 16 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <!-- Angry mouth -->
+  <path d="M12 12 Q16 8 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
   <path d="M8 10 C10 8, 22 8, 24 10" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
   </svg>

--- a/assets/images/rival_walk2.svg
+++ b/assets/images/rival_walk2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffb3b3"/>
+      <stop offset="100%" stop-color="#d95757"/>
+    </linearGradient>
+  </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+        <!-- Legs -->
+  <ellipse cx="11" cy="32" rx="4" ry="2" fill="#ff8080"/>
+  <ellipse cx="21" cy="36" rx="4" ry="2" fill="#ff8080"/>
+    <!-- Head -->
+  <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+  <ellipse cx="8" cy="13" rx="4" ry="2" fill="#ff8080"/>
+  <ellipse cx="24" cy="15" rx="4" ry="2" fill="#ff8080"/>
+  <circle cx="10" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="22" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="10" cy="6" r="2" fill="#000000"/>
+  <circle cx="22" cy="6" r="2" fill="#000000"/>
+  <path d="M12 12 Q16 16 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M8 10 C10 8, 22 8, 24 10" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </svg>

--- a/assets/images/rival_walk2.svg
+++ b/assets/images/rival_walk2.svg
@@ -18,6 +18,7 @@
   <circle cx="22" cy="6" r="4" fill="#ffffff"/>
   <circle cx="10" cy="6" r="2" fill="#000000"/>
   <circle cx="22" cy="6" r="2" fill="#000000"/>
-  <path d="M12 12 Q16 16 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <!-- Angry mouth -->
+  <path d="M12 12 Q16 8 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
   <path d="M8 10 C10 8, 22 8, 24 10" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
   </svg>

--- a/assets/images/rival_walk3.svg
+++ b/assets/images/rival_walk3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="46">
+  <defs>
+    <linearGradient id="frogBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffb3b3"/>
+      <stop offset="100%" stop-color="#d95757"/>
+    </linearGradient>
+  </defs>
+  <!-- Body -->
+  <ellipse cx="16" cy="25" rx="6" ry="7" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+        <!-- Legs -->
+  <ellipse cx="11" cy="36" rx="4" ry="2" fill="#ff8080"/>
+  <ellipse cx="21" cy="32" rx="4" ry="2" fill="#ff8080"/>
+    <!-- Head -->
+  <ellipse cx="16" cy="12" rx="11" ry="10" fill="url(#frogBody)" stroke="#aa3939" stroke-width="2"/>
+  <ellipse cx="8" cy="15" rx="4" ry="2" fill="#ff8080"/>
+  <ellipse cx="24" cy="13" rx="4" ry="2" fill="#ff8080"/>
+  <circle cx="10" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="22" cy="6" r="4" fill="#ffffff"/>
+  <circle cx="10" cy="6" r="2" fill="#000000"/>
+  <circle cx="22" cy="6" r="2" fill="#000000"/>
+  <path d="M12 12 Q16 16 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M8 10 C10 8, 22 8, 24 10" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </svg>

--- a/assets/images/rival_walk3.svg
+++ b/assets/images/rival_walk3.svg
@@ -18,6 +18,7 @@
   <circle cx="22" cy="6" r="4" fill="#ffffff"/>
   <circle cx="10" cy="6" r="2" fill="#000000"/>
   <circle cx="22" cy="6" r="2" fill="#000000"/>
-  <path d="M12 12 Q16 16 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <!-- Angry mouth -->
+  <path d="M12 12 Q16 8 20 12" stroke="#000000" stroke-width="2" fill="none" stroke-linecap="round"/>
   <path d="M8 10 C10 8, 22 8, 24 10" stroke="#e07070" stroke-width="3" fill="none" stroke-linecap="round"/>
   </svg>


### PR DESCRIPTION
## Summary
- generate a red rival character sprite set
- new sprites remove suit and helmet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884918f63988333ab5bbf1b079e03a1