### PR TITLE
Fix broken sleep pod visibility

### DIFF
--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -831,6 +831,8 @@ export default class MazeManager {
         if (this._isNearEntranceOrExit(chunk, x, y)) continue;
         if (chunk.oxygenConsole && chunk.oxygenConsole.x === x && chunk.oxygenConsole.y === y)
           continue;
+        if (chunk.brokenPod && chunk.brokenPod.x === x && chunk.brokenPod.y === y)
+          continue;
         candidates.push({ x, y });
       }
     }


### PR DESCRIPTION
## Summary
- ensure broken sleep pod always shows at the 29th chunk rest point

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68849299a6408333bcfcbc73de56b226