### PR TITLE
Handle final rest point sleep pods

### DIFF
--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -468,8 +468,9 @@ export default class MazeManager {
       this._addOxygenConsole(chunk);
       if (progress === 29) {
         this._addBrokenSleepPod(chunk);
+      } else {
+        this._addSleepPodsWithHero(chunk, 5);
       }
-      this._addSleepPodsWithHero(chunk, 5);
       chunk.electricMachines = [];
       chunk.restPoint = true;
     } else {


### PR DESCRIPTION
## Summary
- remove hero sleep pods from the final rest point
- only spawn one broken pod instead

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688493832ce08333b6519c1d8eaa4cb7