### PR TITLE
Add boss room on 33rd chunk

### DIFF
--- a/src/characters.js
+++ b/src/characters.js
@@ -8,6 +8,7 @@ const SPRITES = {
   auto_gate_open: 'auto_gate_open.svg',
   auto_gate_closed: 'auto_gate_closed.svg',
   door_open: 'airlock_open.svg',
+  reactor_core: 'core_reactor.svg',
   treasure: 'treasure.svg',
   sleep_pod: 'sleep_pod.svg',
   sleep_pod_broken: 'sleep_pod_broken.svg',
@@ -117,6 +118,10 @@ function createAutoGateClosed(scene) {
   return scene.add.image(0, 0, 'auto_gate_closed').setOrigin(0);
 }
 
+function createReactorCore(scene) {
+  return scene.add.image(0, 0, 'reactor_core').setOrigin(0.5);
+}
+
 function createDoorOpen(scene) {
   return scene.add.image(0, 0, 'door_open').setOrigin(0);
 }
@@ -210,6 +215,7 @@ export default {
   createItemSwitch,
   createSpike,
   createElectricMachine,
+  createReactorCore,
   createSleepPod,
   createSleepPodBroken,
   createSleepPodWithHero,

--- a/src/game.js
+++ b/src/game.js
@@ -256,6 +256,7 @@ class GameScene extends Phaser.Scene {
           const blocked =
             tileInfo &&
             (tileInfo.cell === TILE.WALL ||
+              tileInfo.cell === TILE.REACTOR ||
               (tileInfo.cell === TILE.SILVER_DOOR && this.hero.keys === 0) ||
               (tileInfo.cell === TILE.DOOR && this.hero.keys === 0 && !tileInfo.chunk.chunk.exited) ||
               (tileInfo.cell === TILE.AUTO_GATE &&

--- a/src/maze_generator_core.js
+++ b/src/maze_generator_core.js
@@ -39,7 +39,8 @@ export const TILE = {
   SPECIAL: 5,
   SILVER_DOOR: 6,
   OXYGEN: 7,
-  AUTO_GATE: 8
+  AUTO_GATE: 8,
+  REACTOR: 9
 };
 
 const DIRS = [

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -273,10 +273,18 @@ export default class MazeManager {
             info.airTankSprites.push({ x, y, sprite });
             break;
           }
+          case TILE.REACTOR:
+            sprite = Characters.createReactorCore(this.scene);
+            sprite._noAutoSize = true;
+            sprite.setDisplaySize(size * 6, size * 6);
+            info.reactorSprite = sprite;
+            break;
         }
 
         if (sprite) {
-          sprite.setDisplaySize(size, size);
+          if (!sprite._noAutoSize) {
+            sprite.setDisplaySize(size, size);
+          }
           const posX = info.offsetX + x * size;
           const posY = info.offsetY + y * size;
           // Center-origin sprites (like wall corners) should be positioned
@@ -466,9 +474,12 @@ export default class MazeManager {
     const entryDir = this._oppositeDir(doorDir);
 
     const isRestPoint = progress === 14 || progress === 29;
+    const isBossRoom = progress === 32;
 
     let chunk;
-    if (isRestPoint) {
+    if (isBossRoom) {
+      chunk = this._createBossChunk(entryDir);
+    } else if (isRestPoint) {
       chunk = createChunk(this._nextSeed(), 7, entryDir);
       this._ensureEntrance(chunk);
       this._addOxygenConsole(chunk);
@@ -543,7 +554,7 @@ export default class MazeManager {
     }
     chunk.entrance = entrance;
     this._ensureEntrance(chunk);
-    if (!isRestPoint && progress >= 1) {
+    if (!isRestPoint && !isBossRoom && progress >= 1) {
       if (progress === 30 || progress === 31) {
         // Only closed auto gates on the 31st and 32nd chunks
         this._addAutoGate(chunk, 3, true);
@@ -565,11 +576,11 @@ export default class MazeManager {
       const advanced = progress >= 4 && Math.random() < 0.1;
       this._addAirTank(chunk, advanced);
     }
-    if (!isRestPoint && progress >= 2) {
+    if (!isRestPoint && !isBossRoom && progress >= 2) {
       this._addSpikes(chunk);
       this._addElectricMachine(chunk, progress);
     }
-    if (!isRestPoint && progress >= 20) {
+    if (!isRestPoint && !isBossRoom && progress >= 20) {
       if (progress === 20 || Math.random() < 0.3) {
         this._addItemSwitch(chunk);
       }
@@ -953,6 +964,36 @@ export default class MazeManager {
         addMachine();
       }
     }
+  }
+
+  _addReactorCore(chunk) {
+    const c = Math.floor(chunk.size / 2);
+    chunk.tiles[c * chunk.size + c] = TILE.REACTOR;
+    chunk.reactorCore = { x: c, y: c };
+  }
+
+  _createBossChunk(entryDir) {
+    const size = 13;
+    const chunk = {
+      size,
+      seed: this._nextSeed(),
+      entry: entryDir,
+      tiles: new Uint8Array(size * size),
+      door: null,
+      chest: null
+    };
+    // fill with floor and walls around edges
+    for (let y = 0; y < size; y++) {
+      for (let x = 0; x < size; x++) {
+        const idx = y * size + x;
+        chunk.tiles[idx] =
+          x === 0 || y === 0 || x === size - 1 || y === size - 1
+            ? TILE.WALL
+            : TILE.FLOOR;
+      }
+    }
+    this._addReactorCore(chunk);
+    return chunk;
   }
 
   _createLightning(x1, y1, x2, y2, width = 2, depth = 1) {


### PR DESCRIPTION
## Summary
- introduce new sprite `reactor_core` and creator function
- add new tile type `REACTOR`
- spawn a 13x13 boss room with a blocking reactor core at progress 32
- block movement over `REACTOR` tiles and render reactor core

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688495c869fc83339f8eb154db2698de