### PR TITLE
Add hero sleep pod placements for chunks 25-28

### DIFF
--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -593,6 +593,18 @@ export default class MazeManager {
       }
     }
 
+    if (!isRestPoint && !isBossRoom) {
+      if (progress === 25) {
+        this._addSleepPodsWithHero(chunk, 1);
+      } else if (progress === 26) {
+        this._addSleepPodsWithHero(chunk, 3);
+      } else if (progress === 27) {
+        this._addSleepPodsWithHero(chunk, 5);
+      } else if (progress === 28) {
+        this._addSleepPodsWithHero(chunk, 10);
+      }
+    }
+
     const info = this.addChunk(chunk, offsetX, offsetY);
     if (chunk.restPoint) {
       info.restPoint = true;


### PR DESCRIPTION
## Summary
- insert logic in `spawnNext` to add hero sleep pods in chunks 25-28

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688499e52a7c83338296502bdf6e8827