### PR TITLE
Enable meteor attacks in boss room

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -61,7 +61,7 @@ class GameScene extends Phaser.Scene {
     this.cameraManager = new CameraManager(this, this.mazeManager);
     this.starField = new StarField(this);
     this.shield = new Shield(this);
-    this.meteorField = new MeteorField(this, this.shield, gameState.clearedMazes >= 33);
+    this.meteorField = new MeteorField(this, this.shield, gameState.clearedMazes >= 32);
     this._seenFirstChunk = false;
     this.mazeManager.events.on('chunk-created', info => {
       this.cameraManager.expandBounds(info);
@@ -152,6 +152,10 @@ class GameScene extends Phaser.Scene {
           this.bgm.stop();
           this.bgm.play();
         }
+      }
+
+      if (data.info && data.info.bossRoom) {
+        this.checkMeteorFieldActivation();
       }
 
       if (data.info && data.info.index === 1) {
@@ -582,9 +586,12 @@ class GameScene extends Phaser.Scene {
       this.meteorField &&
       this.meteorField.spawnTimer &&
       this.meteorField.spawnTimer.paused &&
-      gameState.clearedMazes >= 33
+      gameState.clearedMazes >= 32
     ) {
       this.meteorField.start();
+      if (this.shield && this.shield.setBaseAlpha) {
+        this.shield.setBaseAlpha(0.5);
+      }
     }
   }
 

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -609,6 +609,9 @@ export default class MazeManager {
     if (chunk.restPoint) {
       info.restPoint = true;
     }
+    if (isBossRoom) {
+      info.bossRoom = true;
+    }
     info.entranceDoorSprite = fromObj.doorSprite;
     if (fromObj.doorSprite) {
       fromObj.sprites = fromObj.sprites.filter(s => s !== fromObj.doorSprite);

--- a/src/shield.js
+++ b/src/shield.js
@@ -4,13 +4,14 @@ export default class Shield {
     // Fixed ellipse 240px wide by 200px tall
     this.radiusX = 120;
     this.radiusY = 100;
+    this.baseAlpha = 0;
     this.sprite = scene
       .add
       .image(0, 0, this._createTexture(this.radiusX, this.radiusY))
       .setOrigin(0.5);
     this.sprite.setDepth(8);
     this.sprite.setScrollFactor(0);
-    this.sprite.setAlpha(0);
+    this.sprite.setAlpha(this.baseAlpha);
     this.updatePosition();
   }
 
@@ -28,11 +29,16 @@ export default class Shield {
     return { x: cam.scrollX + cam.centerX, y: cam.scrollY + cam.centerY };
   }
 
+  setBaseAlpha(alpha) {
+    this.baseAlpha = alpha;
+    this.sprite.setAlpha(alpha);
+  }
+
   flash() {
     this.sprite.setAlpha(1);
     this.scene.tweens.add({
       targets: this.sprite,
-      alpha: 0,
+      alpha: this.baseAlpha,
       duration: 300
     });
   }


### PR DESCRIPTION
## Summary
- activate meteors and reveal the shield once the boss room appears
- mark boss room chunks so GameScene knows when to trigger meteors
- keep the shield visible and flash back to its base transparency when hit

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68849b4b21988333bf48ab3f2bf5c7b1