### PR TITLE
Enable open exits for late game chunks

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -329,6 +329,55 @@ class GameScene extends Phaser.Scene {
           });
         }
       }
+
+      if (
+        curTile.cell === TILE.DOOR &&
+        curTile.chunk.chunk.exited &&
+        !curTile.chunk.chunk._autoSpawned
+      ) {
+        curTile.chunk.chunk._autoSpawned = true;
+        gameState.incrementMazeCount();
+        this.checkMeteorFieldActivation();
+        if (MIDPOINTS.includes(gameState.clearedMazes)) {
+          this.sound.play('midpoint');
+          const ui = this.scene.get('UIScene');
+          if (ui && ui.showMidpoint) {
+            ui.showMidpoint(gameState.clearedMazes);
+          }
+        }
+        this.events.emit('updateChunks', gameState.clearedMazes);
+        const nextInfo = this.mazeManager.spawnNext(
+          gameState.clearedMazes,
+          curTile.chunk,
+          this.heroSprite
+        );
+        let sx = nextInfo.chunk.entrance.x;
+        let sy = nextInfo.chunk.entrance.y;
+        switch (nextInfo.chunk.entry) {
+          case 'N':
+            sy += 1;
+            break;
+          case 'S':
+            sy -= 1;
+            break;
+          case 'W':
+            sx += 1;
+            break;
+          case 'E':
+          default:
+            sx -= 1;
+            break;
+        }
+        this.stopTile = { chunkIndex: nextInfo.index, tx: sx, ty: sy };
+        if (
+          (gameState.clearedMazes === 1 ||
+            gameState.clearedMazes === 15 ||
+            gameState.clearedMazes === 30) &&
+          !this.oxygenTimer
+        ) {
+          this.startOxygenTimer();
+        }
+      }
     }
 
     this.mazeManager.update(delta, this.heroSprite);

--- a/src/game.js
+++ b/src/game.js
@@ -330,6 +330,11 @@ class GameScene extends Phaser.Scene {
         }
       }
 
+    }
+
+    this.mazeManager.update(delta, this.heroSprite);
+    const curTile = this.mazeManager.worldToTile(this.heroSprite.x, this.heroSprite.y);
+    if (curTile) {
       if (
         curTile.cell === TILE.DOOR &&
         curTile.chunk.chunk.exited &&
@@ -378,11 +383,6 @@ class GameScene extends Phaser.Scene {
           this.startOxygenTimer();
         }
       }
-    }
-
-    this.mazeManager.update(delta, this.heroSprite);
-    const curTile = this.mazeManager.worldToTile(this.heroSprite.x, this.heroSprite.y);
-    if (curTile) {
       if (curTile.cell === TILE.CHEST && !curTile.chunk.chunk.chestOpened) {
         curTile.chunk.chunk.chestOpened = true;
         this.sound.play('chest_open');

--- a/src/game.js
+++ b/src/game.js
@@ -141,8 +141,10 @@ class GameScene extends Phaser.Scene {
           alpha: 0,
           duration: 200,
           onComplete: () => {
-            this.oxygenLine.destroy();
-            this.oxygenLine = null;
+            if (this.oxygenLine) {
+              this.oxygenLine.destroy();
+              this.oxygenLine = null;
+            }
           }
         });
       }

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -501,6 +501,15 @@ export default class MazeManager {
       chunk = createChunk(this._nextSeed(), size, entryDir);
     }
 
+    if (progress === 30 || progress === 31) {
+      if (chunk.chest) {
+        const idx = chunk.chest.y * chunk.size + chunk.chest.x;
+        chunk.tiles[idx] = TILE.FLOOR;
+        chunk.chest = null;
+      }
+      chunk.exited = true;
+    }
+
     let { offsetX, offsetY } = this._calcOffset(fromObj, chunk.size, doorDir);
 
     const doorWorldX = fromObj.offsetX + door.x * this.tileSize;
@@ -606,6 +615,9 @@ export default class MazeManager {
     }
 
     const info = this.addChunk(chunk, offsetX, offsetY);
+    if (progress === 30 || progress === 31) {
+      this.openDoor(info);
+    }
     if (chunk.restPoint) {
       info.restPoint = true;
     }


### PR DESCRIPTION
## Summary
- disable chest generation for the 31st and 32nd chunks
- mark those chunks as already exited and open their doors
- when the player reaches an already-open exit, automatically spawn the next chunk

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68849d3d6418833381846dba7f39d304