### PR TITLE
Modify pre-boss chunks

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -258,7 +258,7 @@ class GameScene extends Phaser.Scene {
             (tileInfo.cell === TILE.WALL ||
               tileInfo.cell === TILE.REACTOR ||
               (tileInfo.cell === TILE.SILVER_DOOR && this.hero.keys === 0) ||
-              (tileInfo.cell === TILE.DOOR && this.hero.keys === 0 && !tileInfo.chunk.chunk.exited) ||
+              (tileInfo.cell === TILE.DOOR && this.hero.keys === 0 && !tileInfo.chunk.chunk.exited && !tileInfo.chunk.chunk.doorOpen) ||
               (tileInfo.cell === TILE.AUTO_GATE &&
                 tileInfo.chunk.chunk.autoGates &&
                 tileInfo.chunk.chunk.autoGates.find(
@@ -461,7 +461,7 @@ class GameScene extends Phaser.Scene {
       }
 
       if (curTile.cell === TILE.DOOR && !curTile.chunk.chunk.exited) {
-        if (this.hero.useKey()) {
+        if (curTile.chunk.chunk.doorOpen || this.hero.useKey()) {
           this.mazeManager.openDoor(curTile.chunk);
           this.sound.play('door_open');
           this.cameraManager.zoomHeroFocus();

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -228,7 +228,9 @@ export default class MazeManager {
             info.oxygenPosition = { x, y };
             break;
           case TILE.DOOR:
-            sprite = Characters.createExit(this.scene);
+            sprite = chunk.doorOpen
+              ? Characters.createDoorOpen(this.scene)
+              : Characters.createExit(this.scene);
             info.doorSprite = sprite;
             info.doorPosition = { x, y };
             break;
@@ -506,6 +508,14 @@ export default class MazeManager {
     } else {
       const { size } = pickMazeConfig(progress + 1, progress);
       chunk = createChunk(this._nextSeed(), size, entryDir);
+      if (progress === 30 || progress === 31) {
+        if (chunk.chest) {
+          const idx = chunk.chest.y * size + chunk.chest.x;
+          chunk.tiles[idx] = TILE.FLOOR;
+          chunk.chest = null;
+        }
+        chunk.doorOpen = true;
+      }
     }
 
     let { offsetX, offsetY } = this._calcOffset(fromObj, chunk.size, doorDir);


### PR DESCRIPTION
## Summary
- disable key spawn two chunks before the boss
- render exit door open for those chunks
- allow entering opened door without a key

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884bf6adaa88333bbd5391beb9545c9