### PR TITLE
Add rectangular sizes to maze table

### DIFF
--- a/src/maze_generator_core.js
+++ b/src/maze_generator_core.js
@@ -214,3 +214,168 @@ export function createChunk(seed, size = 13, entry = 'W') {
   if (size % 2 === 0) size += 1; // enforce odd sizes consistently
   return new MazeChunk(seed, size, entry);
 }
+
+export class MazeRectChunk {
+  constructor(seed = 'seed', width = 13, height = 13, entry = 'W') {
+    if (width % 2 === 0) width += 1;
+    if (height % 2 === 0) height += 1;
+    this.width = width;
+    this.height = height;
+    this.seed = seed;
+    this.entry = entry;
+    this.tiles = new Uint8Array(width * height);
+    this.door = null;
+    this.chest = null;
+    this._generate();
+  }
+
+  _generate() {
+    const rng = new RNG(this.seed);
+    const w = this.width;
+    const h = this.height;
+    const tiles = this.tiles;
+    tiles.fill(TILE.WALL);
+
+    const stack = [];
+    const maxX = Math.floor((w - 1) / 2);
+    const maxY = Math.floor((h - 1) / 2);
+    const startX = rng.nextInt(maxX) * 2 + 1;
+    const startY = rng.nextInt(maxY) * 2 + 1;
+    stack.push({ x: startX, y: startY });
+    tiles[index(startX, startY, w)] = TILE.FLOOR;
+
+    while (stack.length) {
+      const { x, y } = stack[stack.length - 1];
+      const neighbors = [];
+      for (const dir of DIRS) {
+        const nx = x + dir.dx * 2;
+        const ny = y + dir.dy * 2;
+        if (
+          nx > 0 && ny > 0 && nx < w - 1 && ny < h - 1 &&
+          tiles[index(nx, ny, w)] === TILE.WALL
+        ) {
+          neighbors.push({ dir, nx, ny });
+        }
+      }
+      if (neighbors.length) {
+        const n = neighbors[rng.nextInt(neighbors.length)];
+        tiles[index(x + n.dir.dx, y + n.dir.dy, w)] = TILE.FLOOR;
+        tiles[index(n.nx, n.ny, w)] = TILE.FLOOR;
+        stack.push({ x: n.nx, y: n.ny });
+      } else {
+        stack.pop();
+      }
+    }
+
+    this._placeSpecials(rng);
+    this._addDetours(rng);
+  }
+
+  _randomFloor(rng) {
+    const w = this.width;
+    const h = this.height;
+    let x, y;
+    do {
+      x = rng.nextInt(w - 2) + 1;
+      y = rng.nextInt(h - 2) + 1;
+    } while (this.tiles[index(x, y, w)] !== TILE.FLOOR);
+    return { x, y };
+  }
+
+  _placeSpecials(rng) {
+    const w = this.width;
+    const h = this.height;
+    const tiles = this.tiles;
+    const chest = this._randomFloor(rng);
+    tiles[index(chest.x, chest.y, w)] = TILE.CHEST;
+    this.chest = chest;
+
+    const sides = ['N', 'E', 'S', 'W'].filter(s => s !== this.entry);
+    const side = sides[rng.nextInt(sides.length)];
+    const door = this._doorPosition(side, rng);
+    const back = DIRS.find(d => d.name === side);
+    const ix = door.x - back.dx;
+    const iy = door.y - back.dy;
+    if (tiles[index(ix, iy, w)] === TILE.WALL) {
+      tiles[index(ix, iy, w)] = TILE.FLOOR;
+    }
+    tiles[index(door.x, door.y, w)] = TILE.DOOR;
+    this.door = { dir: side, x: door.x, y: door.y };
+
+    if (!this._isReachable(chest, door)) {
+      this.seed += '_retry';
+      this._generate();
+    }
+  }
+
+  _addDetours(rng) {
+    const w = this.width;
+    const h = this.height;
+    const tiles = this.tiles;
+    const base = Math.min(w, h);
+    const max = Math.max(1, Math.floor(base / 3));
+    let count = rng.nextInt(max) + 1;
+    if (base >= 13) {
+      count += 2;
+    } else if (base >= 11) {
+      count += 1;
+    }
+    for (let i = 0; i < count; i++) {
+      const x = rng.nextInt(w - 2) + 1;
+      const y = rng.nextInt(h - 2) + 1;
+      const idx = index(x, y, w);
+      if (tiles[idx] === TILE.WALL) {
+        tiles[idx] = TILE.FLOOR;
+      }
+    }
+  }
+
+  _doorPosition(side, rng) {
+    const w = this.width;
+    const h = this.height;
+    switch (side) {
+      case 'N':
+        return { x: rng.nextInt(w - 2) + 1, y: 0 };
+      case 'S':
+        return { x: rng.nextInt(w - 2) + 1, y: h - 1 };
+      case 'W':
+        return { x: 0, y: rng.nextInt(h - 2) + 1 };
+      case 'E':
+      default:
+        return { x: w - 1, y: rng.nextInt(h - 2) + 1 };
+    }
+  }
+
+  _isReachable(start, goal) {
+    const w = this.width;
+    const h = this.height;
+    const tiles = this.tiles;
+    const visited = new Uint8Array(w * h);
+    const queue = [start];
+    visited[index(start.x, start.y, w)] = 1;
+
+    while (queue.length) {
+      const { x, y } = queue.shift();
+      if (x === goal.x && y === goal.y) return true;
+      for (const dir of DIRS) {
+        const nx = x + dir.dx;
+        const ny = y + dir.dy;
+        if (
+          nx >= 0 && ny >= 0 && nx < w && ny < h &&
+          !visited[index(nx, ny, w)] &&
+          tiles[index(nx, ny, w)] !== TILE.WALL
+        ) {
+          visited[index(nx, ny, w)] = 1;
+          queue.push({ x: nx, y: ny });
+        }
+      }
+    }
+    return false;
+  }
+}
+
+export function createRectChunk(seed, width = 13, height = 13, entry = 'W') {
+  if (width % 2 === 0) width += 1;
+  if (height % 2 === 0) height += 1;
+  return new MazeRectChunk(seed, width, height, entry);
+}

--- a/src/maze_table.js
+++ b/src/maze_table.js
@@ -1,16 +1,30 @@
 export const MAZE_TABLE = [
-  { stage: 1, sizes: [7] },
+  { stage: 1, shapes: [{ size: 7 }] },
   // From the second chunk onward allow a wider range including 7 again
-  { stage: 2, sizes: [7, 9, 11, 13] }
+  { stage: 2, shapes: [{ size: 7 }, { size: 9 }, { size: 11 }, { size: 13 }] },
+  // Introduce 5x13 rectangular chunks from chunk 12 onward
+  { stage: 12, shapes: [{ width: 5, height: 13 }] },
+  // Introduce 7x13 rectangular chunks from chunk 22 onward
+  { stage: 22, shapes: [{ width: 7, height: 13 }] }
 ];
 
 export function pickMazeConfig(stage, progress = 0) {
   if (progress >= 30) {
     return { size: 13 };
   }
-  const entry = [...MAZE_TABLE].reverse().find(e => stage >= e.stage) || MAZE_TABLE[0];
-  let sizes = entry.sizes.slice();
-  // Gate larger chunk sizes by progress
+
+  // Gather all available shapes up to the current stage
+  let shapes = [];
+  for (const entry of MAZE_TABLE) {
+    if (stage >= entry.stage) {
+      shapes = shapes.concat(entry.shapes);
+    } else {
+      break;
+    }
+  }
+
+  // Extract square sizes for gating logic
+  let sizes = shapes.filter(s => 'size' in s).map(s => s.size);
   if (progress < 6) {
     // Only 7x7 and 9x9 before the 7th chunk
     sizes = sizes.filter(s => s < 11);
@@ -18,7 +32,16 @@ export function pickMazeConfig(stage, progress = 0) {
     // Allow up to 11x11 from chunks 7-9
     sizes = sizes.filter(s => s <= 11);
   }
-  if (!sizes.length) sizes = entry.sizes;
-  const size = sizes[Math.floor(Math.random() * sizes.length)];
-  return { size };
+
+  // Filter shapes based on allowed square sizes
+  let allowed = shapes.filter(s => {
+    if ('size' in s) {
+      return sizes.includes(s.size);
+    }
+    return true; // rectangular shapes are not size-gated
+  });
+
+  if (!allowed.length) allowed = shapes;
+  const choice = allowed[Math.floor(Math.random() * allowed.length)];
+  return choice;
 }


### PR DESCRIPTION
## Summary
- extend `MAZE_TABLE` with 5x13 and 7x13 rectangular chunk entries
- update `pickMazeConfig` to handle shape objects

## Testing
- `node - <<'EOF'
const {createRectChunk} = require('./src/maze_generator_core.js');
const c = createRectChunk('seed',5,13);
console.log(c.width,c.height,c.tiles.length);
EOF`
- `node - <<'EOF'
const {createRectChunk} = require('./src/maze_generator_core.js');
const c = createRectChunk('seed2',7,13);
console.log(c.width,c.height,c.tiles.length);
EOF`
- `node - <<'EOF'
const {pickMazeConfig} = require('./src/maze_table.js');
for(let i=0;i<3;i++) console.log(pickMazeConfig(12,11));
for(let i=0;i<3;i++) console.log(pickMazeConfig(22,21));
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68849d87f7488333ac7680bd805f8b52