### PR TITLE
Play boss music on entering boss room

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -35,6 +35,8 @@ class GameScene extends Phaser.Scene {
     this.oxygenTimer = null;
     this.rivalTimer = null;
     this.bgm = null;
+    this.bossBgm1 = null;
+    this.bossBgm2 = null;
     this.isGameOver = false;
     this.lastSpikeTile = null;
     this.lastShockTile = null;
@@ -62,6 +64,8 @@ class GameScene extends Phaser.Scene {
 
     this.sound.stopAll();
     this.bgm = this.sound.add('bgm', { loop: true });
+    this.bossBgm1 = this.sound.add('boss_bgm_1', { loop: true });
+    this.bossBgm2 = this.sound.add('boss_bgm_2', { loop: true });
 
     this.worldLayer = this.add.container(0, 0);
     this.mazeManager = new MazeManager(this);
@@ -132,6 +136,12 @@ class GameScene extends Phaser.Scene {
         if (this.bgm && this.bgm.isPlaying) {
           this.bgm.stop();
         }
+        if (this.bossBgm1 && this.bossBgm1.isPlaying) {
+          this.bossBgm1.stop();
+        }
+        if (this.bossBgm2 && this.bossBgm2.isPlaying) {
+          this.bossBgm2.stop();
+        }
         this.sound.play('pick_up');
         this.hero.oxygen = this.hero.maxOxygen;
         this.events.emit('updateOxygen', 1);
@@ -163,9 +173,29 @@ class GameScene extends Phaser.Scene {
       }
 
       if (!data.info || !data.info.restPoint) {
-        if (this.bgm) {
-          this.bgm.stop();
-          this.bgm.play();
+        if (data.info && data.info.isBossRoom) {
+          if (this.bgm && this.bgm.isPlaying) {
+            this.bgm.stop();
+          }
+          if (this.bossBgm1) {
+            this.bossBgm1.stop();
+            this.bossBgm1.play();
+          }
+          if (this.bossBgm2) {
+            this.bossBgm2.stop();
+            this.bossBgm2.play();
+          }
+        } else {
+          if (this.bossBgm1 && this.bossBgm1.isPlaying) {
+            this.bossBgm1.stop();
+          }
+          if (this.bossBgm2 && this.bossBgm2.isPlaying) {
+            this.bossBgm2.stop();
+          }
+          if (this.bgm) {
+            this.bgm.stop();
+            this.bgm.play();
+          }
         }
       }
 
@@ -797,6 +827,12 @@ class GameScene extends Phaser.Scene {
     }
     if (this.bgm) {
       this.bgm.stop();
+    }
+    if (this.bossBgm1) {
+      this.bossBgm1.stop();
+    }
+    if (this.bossBgm2) {
+      this.bossBgm2.stop();
     }
     this.sound.stopAll();
     this.sound.play('game_over');

--- a/src/loading_scene.js
+++ b/src/loading_scene.js
@@ -52,6 +52,8 @@ export default class LoadingScene extends Phaser.Scene {
     this.load.audio('spike_damage', 'assets/sounds/09_spike_damage.wav');
     this.load.audio('item_spawn', 'assets/sounds/10_item_spawn.wav');
     this.load.audio('bgm', 'assets/sounds/music_ambience.wav');
+    this.load.audio('boss_bgm_1', 'assets/sounds/music_boss_1.wav');
+    this.load.audio('boss_bgm_2', 'assets/sounds/music_boss_2.wav');
   }
 
   create() {


### PR DESCRIPTION
## Summary
- load boss music in `LoadingScene`
- initialize boss bgm audio in `GameScene`
- stop bgm when entering rest areas
- switch to dual boss bgm in boss room and revert when leaving
- stop boss bgm on game over

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884d07ff43083339e98c837137f7f18