### PR TITLE
Add rival item seeking behavior

### DIFF
--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -1262,6 +1262,25 @@ export default class MazeManager {
     });
   }
 
+  spawnItemSwitch(info) {
+    if (!info || (info.itemSwitchSprite && info.chunk.itemSwitch && !info.chunk.itemSwitch.triggered)) {
+      return;
+    }
+    const spot = this._findDropSpot(info.chunk);
+    if (!spot) return;
+    const { x, y } = spot;
+    const size = this.tileSize;
+    const sprite = Characters.createItemSwitch(this.scene);
+    sprite.setDisplaySize(size, size);
+    sprite.setPosition(info.offsetX + x * size, info.offsetY + y * size);
+    sprite.alpha = 0;
+    this.scene.worldLayer.add(sprite);
+    this.scene.tweens.add({ targets: sprite, alpha: 1, duration: 200 });
+    info.itemSwitchSprite = sprite;
+    info.itemSwitchPosition = { x, y };
+    info.chunk.itemSwitch = { x, y, triggered: false };
+  }
+
   _findDropSpot(chunk) {
     const size = chunk.size;
     const t = chunk.tiles;


### PR DESCRIPTION
## Summary
- spawn item switches dynamically
- have rival search for nearby item switches or oxygen tanks
- rival now picks up items the same as the hero
- stop timers when the rival or hero dies

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6884d3e527fc8333b7f2e3fc7c006434