### PR TITLE
Fix input buffer to stop immediate after key release

### DIFF
--- a/src/input_buffer.js
+++ b/src/input_buffer.js
@@ -52,6 +52,7 @@ export default class InputBuffer {
     if (!dir) return;
     if (this.holdKeys[dir]) {
       delete this.holdKeys[dir];
+      this.buffer = this.buffer.filter(entry => entry.dir !== dir);
       const index = this.holdOrder.indexOf(dir);
       if (index !== -1) {
         this.holdOrder.splice(index, 1);


### PR DESCRIPTION
## Summary
- ensure released direction entries are removed from input buffer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884dc0fcf9c8333ab404c8e687ab2d6