### PR TITLE
Implement hold before midpoint text effect

### DIFF
--- a/src/ui_scene.js
+++ b/src/ui_scene.js
@@ -278,6 +278,7 @@ export default class UIScene extends Phaser.Scene {
       scale: 2,
       alpha: 0,
       duration: tweenDuration,
+      delay: 400,
       ease: 'Quad.easeOut',
       onComplete: () => {
         base.destroy();


### PR DESCRIPTION
## Summary
- add a 400 ms delay before midpoint text begins scaling and fading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884dc9f3d448333b564428047078871