### PR TITLE
Implement rival afterimage and adjust oxygen rate

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -138,10 +138,15 @@ export function spawnAfterimage(
   x,
   y,
   flipX = false,
+  displayWidth = null,
+  displayHeight = null,
   duration = 300,
-  alpha = 0.5
+  alpha = 0.3
 ) {
   const img = scene.add.image(x, y, textureKey).setOrigin(0.5);
+  if (displayWidth && displayHeight) {
+    img.setDisplaySize(displayWidth, displayHeight);
+  }
   img.setFlipX(flipX);
   img.setAlpha(alpha);
   img.setDepth(0);

--- a/src/effects.js
+++ b/src/effects.js
@@ -129,3 +129,28 @@ export function addReactorPulse(scene, sprite, size) {
   createPulse(1000);
   return container;
 }
+
+// Create a fading afterimage at the specified position using the
+// given texture. Primarily used for rival movement trails.
+export function spawnAfterimage(
+  scene,
+  textureKey,
+  x,
+  y,
+  flipX = false,
+  duration = 300,
+  alpha = 0.5
+) {
+  const img = scene.add.image(x, y, textureKey).setOrigin(0.5);
+  img.setFlipX(flipX);
+  img.setAlpha(alpha);
+  img.setDepth(0);
+  scene.worldLayer.add(img);
+  scene.tweens.add({
+    targets: img,
+    alpha: 0,
+    duration,
+    ease: 'Quad.easeOut',
+    onComplete: () => img.destroy()
+  });
+}

--- a/src/game.js
+++ b/src/game.js
@@ -676,7 +676,9 @@ class GameScene extends Phaser.Scene {
             this.rivalImage.texture.key,
             this.rivalSprite.x,
             this.rivalSprite.y,
-            this.rivalImage.flipX
+            this.rivalImage.flipX,
+            this.rivalImage.displayWidth,
+            this.rivalImage.displayHeight
           );
         };
         spawnTrail();

--- a/src/game.js
+++ b/src/game.js
@@ -127,13 +127,21 @@ class GameScene extends Phaser.Scene {
       this.sound.play('chunk_generate_2');
 
       if (data.info && data.info.restPoint) {
-        const size = this.mazeManager.tileSize;
-        const cx = data.info.offsetX + data.info.oxygenPosition.x * size + size / 2;
-        const cy = data.info.offsetY + data.info.oxygenPosition.y * size + size / 2;
-        this.oxygenConsole = { x: cx, y: cy };
-        if (!this.oxygenLine) {
-          this.oxygenLine = this.add.graphics();
-          this.worldLayer.add(this.oxygenLine);
+        if (data.info.oxygenPosition) {
+          const size = this.mazeManager.tileSize;
+          const cx = data.info.offsetX + data.info.oxygenPosition.x * size + size / 2;
+          const cy = data.info.offsetY + data.info.oxygenPosition.y * size + size / 2;
+          this.oxygenConsole = { x: cx, y: cy };
+          if (!this.oxygenLine) {
+            this.oxygenLine = this.add.graphics();
+            this.worldLayer.add(this.oxygenLine);
+          }
+        } else {
+          this.oxygenConsole = null;
+          if (this.oxygenLine) {
+            this.oxygenLine.destroy();
+            this.oxygenLine = null;
+          }
         }
         if (this.bgm && this.bgm.isPlaying) {
           this.bgm.stop();


### PR DESCRIPTION
## Summary
- add generic `spawnAfterimage` effect
- show afterimage trail while the rival moves
- have rival oxygen decrease by 1.5 per second
- clear the new timer on death and game over

## Testing
- `node --check src/game.js`
- `node --check src/effects.js`


------
https://chatgpt.com/codex/tasks/task_e_6884dd871dbc8333919fcb7d73ff739f