### PR TITLE
Implement ending room after boss

### DIFF
--- a/src/characters.js
+++ b/src/characters.js
@@ -53,7 +53,9 @@ const SPRITES = {
   floor_scratch1: 'floor_scratch1.svg',
   floor_scratch2: 'floor_scratch2.svg',
   item_switch: 'floor_switch_red.svg',
-  hero_spacesuit: 'hero_spacesuit.svg'
+  hero_spacesuit: 'hero_spacesuit.svg',
+  monitor_computer: 'monitor_computer.svg',
+  monitor_display: 'monitor_display.svg'
 };
 
 const canvases = {};
@@ -212,6 +214,14 @@ function createHeroSpacesuit(scene) {
   return scene.add.image(0, 0, 'hero_spacesuit').setOrigin(0);
 }
 
+function createMonitorComputer(scene) {
+  return scene.add.image(0, 0, 'monitor_computer').setOrigin(0);
+}
+
+function createMonitorDisplay(scene) {
+  return scene.add.image(0, 0, 'monitor_display').setOrigin(0);
+}
+
 export default {
   ready,
   registerTextures,
@@ -244,5 +254,7 @@ export default {
   createRival,
   createHeroSpacesuit,
   createArrow,
-  createFloorDecal
+  createFloorDecal,
+  createMonitorComputer,
+  createMonitorDisplay
 };

--- a/src/game.js
+++ b/src/game.js
@@ -173,6 +173,13 @@ class GameScene extends Phaser.Scene {
         });
       }
 
+      if (data.info && data.info.isEndingRoom) {
+        if (this.oxygenTimer) {
+          this.oxygenTimer.remove();
+          this.oxygenTimer = null;
+        }
+      }
+
       if (!data.info || !data.info.restPoint) {
         if (data.info && data.info.isBossRoom) {
           if (this.bgm && this.bgm.isPlaying) {


### PR DESCRIPTION
## Summary
- add new monitor sprites and creators
- create special ending room chunk with monitors
- close previous room and stop oxygen in ending room

## Testing
- `node --check src/characters.js`
- `node --check src/maze_manager.js`
- `node --check src/game.js`


------
https://chatgpt.com/codex/tasks/task_e_6884e0ec81348333bb3a2abb01060321