### PR TITLE
Spawn key after rival oxygen depletion

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -713,6 +713,7 @@ class GameScene extends Phaser.Scene {
         this.rivalMoving = true;
         const duration = (size / this.rival.speed) * 1000;
         const spawnTrail = () => {
+          if (!this.rivalImage) return;
           spawnAfterimage(
             this,
             this.rivalImage.texture.key,
@@ -763,8 +764,10 @@ class GameScene extends Phaser.Scene {
               this.rivalTrailTimer.remove();
               this.rivalTrailTimer = null;
             }
-            spawnTrail();
-            this.rivalImage.setTexture(frames[0]);
+            if (this.rivalImage) {
+              spawnTrail();
+              this.rivalImage.setTexture(frames[0]);
+            }
           }
         });
         return true;

--- a/src/game.js
+++ b/src/game.js
@@ -1017,7 +1017,13 @@ class GameScene extends Phaser.Scene {
     };
     evaporate();
     const evapTimer = this.time.addEvent({ delay: 100, repeat: 5, callback: evaporate });
+    const dropX = this.rivalSprite.x;
+    const dropY = this.rivalSprite.y;
     this.rivalSprite.setVisible(false);
+    const tile = this.mazeManager.worldToTile(dropX, dropY);
+    if (tile) {
+      this.mazeManager.spawnKeyDrop(tile.chunk, tile.tx, tile.ty);
+    }
     this.events.emit('updateRivalOxygen', 0);
     this.time.delayedCall(1000, () => {
       evapTimer.remove();

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -1323,6 +1323,32 @@ export default class MazeManager {
     });
   }
 
+  spawnKeyDrop(info, x, y) {
+    if (!info) return;
+    const size = this.tileSize;
+    const sprite = Characters.createKey(this.scene);
+    sprite.setDisplaySize(size, size);
+    const startY = this.scene.cameras.main.worldView.y - size;
+    sprite.setPosition(info.offsetX + x * size, startY);
+    sprite.alpha = 0;
+    this.scene.worldLayer.add(sprite);
+    info.sprites.push(sprite);
+    this.scene.tweens.add({ targets: sprite, alpha: 1, duration: 200 });
+    this.scene.tweens.add({
+      targets: sprite,
+      y: info.offsetY + y * size,
+      duration: 400,
+      ease: 'Quad.easeIn',
+      onComplete: () => {
+        info.chestSprite = sprite;
+        info.chestPosition = { x, y };
+        const idx = y * info.chunk.width + x;
+        info.chunk.tiles[idx] = TILE.CHEST;
+        info.chunk.chest = { x, y };
+      }
+    });
+  }
+
   spawnItemSwitch(info) {
     if (!info || (info.itemSwitchSprite && info.chunk.itemSwitch && !info.chunk.itemSwitch.triggered)) {
       return;


### PR DESCRIPTION
## Summary
- drop a key when the rival evaporates from running out of oxygen
- add `spawnKeyDrop` helper in `MazeManager`

## Testing
- `node --check src/game.js`
- `node --check src/maze_manager.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6884e2554e1483339ce8013dc94a0c2d