### PR TITLE
Add oxygen drop to boss room

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -224,6 +224,11 @@ class GameScene extends Phaser.Scene {
         if (ui && ui.showMidpoint) {
           ui.showMidpoint('SURVIVE!');
         }
+        this.time.delayedCall(3000, () => {
+          for (let i = 0; i < 6; i++) {
+            this.mazeManager.spawnAirTankDrop(data.info);
+          }
+        });
       }
 
       if (data.info && data.info.index === 1) {


### PR DESCRIPTION
## Summary
- spawn 6 oxygen tanks three seconds after entering the boss room

## Testing
- `node -v` *(fail: no command)*

------
https://chatgpt.com/codex/tasks/task_e_68856bbe0e5483339752739712e20fac