### PR TITLE
Add rival pause behavior

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -51,6 +51,8 @@ class GameScene extends Phaser.Scene {
     this.rivalTrailTimer = null;
     this.rivalSwitchTimer = null;
     this.rivalSpikeTimer = null;
+    this.rivalPauseTimer = null;
+    this.rivalPaused = false;
     this.lastRivalSpikeTile = null;
     this.stopTile = null;
   }
@@ -686,7 +688,7 @@ class GameScene extends Phaser.Scene {
     }
   }
 
-    if (this.rivalSprite && !this.rivalMoving && !this.isGameOver) {
+    if (this.rivalSprite && !this.rivalMoving && !this.rivalPaused && !this.isGameOver) {
       let dirs = null;
       const target = this._findNearestRivalTarget();
       if (target) {
@@ -900,6 +902,24 @@ class GameScene extends Phaser.Scene {
     });
   }
 
+  startRivalPauseTimer() {
+    if (!this.rival) return;
+    const schedule = () => {
+      this.rivalPauseTimer = this.time.delayedCall(
+        Phaser.Math.Between(1000, 3000),
+        () => {
+          if (!this.rival || this.isGameOver) return;
+          this.rivalPaused = true;
+          this.time.delayedCall(200, () => {
+            this.rivalPaused = false;
+            schedule();
+          });
+        }
+      );
+    };
+    schedule();
+  }
+
   _findNearestRivalTarget() {
     if (!this.rivalSprite) return null;
     const rx = this.rivalSprite.x;
@@ -1052,6 +1072,7 @@ class GameScene extends Phaser.Scene {
     this.startRivalOxygenTimer();
     this.startRivalSwitchTimer();
     this.startRivalSpikeTimer();
+    this.startRivalPauseTimer();
     this.events.emit('updateRivalOxygen', 1);
   }
 
@@ -1069,6 +1090,10 @@ class GameScene extends Phaser.Scene {
     if (this.rivalSpikeTimer) {
       this.rivalSpikeTimer.remove();
       this.rivalSpikeTimer = null;
+    }
+    if (this.rivalPauseTimer) {
+      this.rivalPauseTimer.remove();
+      this.rivalPauseTimer = null;
     }
     if (this.rivalAnimTimer) {
       this.rivalAnimTimer.remove();
@@ -1133,6 +1158,10 @@ class GameScene extends Phaser.Scene {
     if (this.rivalSpikeTimer) {
       this.rivalSpikeTimer.remove();
       this.rivalSpikeTimer = null;
+    }
+    if (this.rivalPauseTimer) {
+      this.rivalPauseTimer.remove();
+      this.rivalPauseTimer = null;
     }
     if (this.bgm) {
       this.bgm.stop();


### PR DESCRIPTION
## Summary
- make the rival periodically stop moving
- spawn rival pause timer when rival appears
- clean up timer on rival death or game over

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68856be19b288333a100ee1b11ba1dbd