### PR TITLE
Increase rival pause frequency

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -911,7 +911,7 @@ class GameScene extends Phaser.Scene {
     if (!this.rival) return;
     const schedule = () => {
       this.rivalPauseTimer = this.time.delayedCall(
-        Phaser.Math.Between(1000, 3000),
+        Phaser.Math.Between(333, 1000),
         () => {
           if (!this.rival || this.isGameOver) return;
           this.rivalPaused = true;


### PR DESCRIPTION
## Summary
- adjust rival pause timer for more frequent pauses

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6885871684e08333a8bebb731efe65f3