### PR TITLE
Fix rival animation null reference

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -757,7 +757,9 @@ class GameScene extends Phaser.Scene {
           loop: true,
           callback: () => {
             this.rivalAnimIndex = (this.rivalAnimIndex + 1) % frames.length;
-            this.rivalImage.setTexture(frames[this.rivalAnimIndex]);
+            if (this.rivalImage) {
+              this.rivalImage.setTexture(frames[this.rivalAnimIndex]);
+            }
           }
         });
         this.tweens.add({


### PR DESCRIPTION
## Summary
- guard against `rivalImage` being `null` during the rival animation timer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68864ef02b0c83339feef2ef175399c4