### PR TITLE
Ensure rival-created items are cleaned up with their chunk

### DIFF
--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -1411,6 +1411,7 @@ export default class MazeManager {
     sprite.setPosition(info.offsetX + x * size, info.offsetY + y * size);
     sprite.alpha = 0;
     this.scene.worldLayer.add(sprite);
+    info.sprites.push(sprite);
     this.scene.tweens.add({ targets: sprite, alpha: 1, duration: 200 });
     info.itemSwitchSprite = sprite;
     info.itemSwitchPosition = { x, y };
@@ -1428,6 +1429,7 @@ export default class MazeManager {
     sprite.setPosition(info.offsetX + x * size, info.offsetY + y * size);
     sprite.alpha = 0;
     this.scene.worldLayer.add(sprite);
+    info.sprites.push(sprite);
     this.scene.tweens.add({ targets: sprite, alpha: 1, duration: 200 });
     info.spikeSprites.push({ x, y, sprite });
     if (!info.chunk.spikes) info.chunk.spikes = [];


### PR DESCRIPTION
## Summary
- fix item switch & spike sprites so they're added to chunk sprite list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688650ac96e48333924e96cbadee0dd0