### PR TITLE
Fix rival initialization on retry

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -62,6 +62,38 @@ class GameScene extends Phaser.Scene {
   }
 
   create() {
+    // Reset rival-related state in case the scene is restarting
+    if (this.rivalSprite) {
+      this.rivalSprite.destroy();
+    }
+    if (this.rivalTrailTimer) {
+      this.rivalTrailTimer.remove();
+    }
+    if (this.rivalSwitchTimer) {
+      this.rivalSwitchTimer.remove();
+    }
+    if (this.rivalSpikeTimer) {
+      this.rivalSpikeTimer.remove();
+    }
+    if (this.rivalPauseTimer) {
+      this.rivalPauseTimer.remove();
+    }
+    if (this.rivalAnimTimer) {
+      this.rivalAnimTimer.remove();
+    }
+    this.rival = null;
+    this.rivalSprite = null;
+    this.rivalImage = null;
+    this.rivalMoving = false;
+    this.rivalAnimTimer = null;
+    this.rivalAnimIndex = 0;
+    this.rivalTrailTimer = null;
+    this.rivalSwitchTimer = null;
+    this.rivalSpikeTimer = null;
+    this.rivalPauseTimer = null;
+    this.rivalPaused = false;
+    this.lastRivalSpikeTile = null;
+
     this.hero = new HeroState();
     this.isMoving = false;
     this.isGameOver = false;


### PR DESCRIPTION
## Summary
- reset all rival-related properties in GameScene.create so that the rival respawns correctly when restarting the game

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688650f5272c833380c4bca74c8496b9