### PR TITLE
Open exit door after obtaining key

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -449,6 +449,7 @@ class GameScene extends Phaser.Scene {
         this.sound.play('chest_open');
         this.mazeManager.removeChest(curTile.chunk);
         this.hero.addKey();
+        this.mazeManager.openDoor(curTile.chunk);
         this.mazeManager.openAllSilverDoors(curTile.chunk);
         this.events.emit('updateKeys', this.hero.keys);
       }

--- a/src/maze_manager.js
+++ b/src/maze_manager.js
@@ -1265,6 +1265,9 @@ export default class MazeManager {
     if (info && info.entranceDoorSprite) {
       info.entranceDoorSprite.setTexture('exit');
     }
+    if (info && info.chunk) {
+      info.chunk.doorOpen = true;
+    }
   }
 
   openSilverDoor(info, x, y) {


### PR DESCRIPTION
## Summary
- automatically open the exit door the instant a key is collected
- mark the current chunk's door as open

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68878d17c0a48333a6acc5c95e7745d8