### PR TITLE
Add ending credit scene

### DIFF
--- a/src/ending_scene.js
+++ b/src/ending_scene.js
@@ -1,0 +1,86 @@
+const VIRTUAL_WIDTH = 480;
+const VIRTUAL_HEIGHT = 270;
+import { evaporateArea } from './effects.js';
+import gameState from './game-state.js';
+
+export default class EndingScene extends Phaser.Scene {
+  constructor() {
+    super('EndingScene');
+    this.message = null;
+    this.credit = null;
+  }
+
+  create() {
+    const { width, height } = this.scale.gameSize;
+    this.cameras.main.setViewport(
+      (width - VIRTUAL_WIDTH * 2) / 2,
+      (height - VIRTUAL_HEIGHT * 2) / 2,
+      VIRTUAL_WIDTH * 2,
+      VIRTUAL_HEIGHT * 2
+    );
+
+    this.mask = this.add
+      .rectangle(0, 0, VIRTUAL_WIDTH * 2, VIRTUAL_HEIGHT * 2, 0x000000)
+      .setOrigin(0)
+      .setAlpha(0);
+    this.mask.setDepth(1000);
+    this.tweens.add({ targets: this.mask, alpha: 0.6, duration: 1000 });
+
+    const style = { fontFamily: 'monospace', fontSize: '64px', color: '#ffffff' };
+    this.message = this.add
+      .text(40, VIRTUAL_HEIGHT, 'YOU TOOK A BREATH', style)
+      .setOrigin(0, 0.5)
+      .setDepth(1001);
+
+    const gameScene = this.scene.get('GameScene');
+    if (gameScene && gameScene.cameraManager) {
+      gameScene.cameraManager.setZoom(1, 10000);
+    }
+
+    this.time.delayedCall(10000, () => {
+      evaporateArea(
+        this,
+        this.message.x,
+        this.message.y - this.message.height / 2,
+        this.message.width,
+        this.message.height,
+        0xffffff
+      );
+      this.message.destroy();
+      this.showCredit();
+    });
+  }
+
+  showCredit() {
+    const style = { fontFamily: 'monospace', fontSize: '48px', color: '#ffffff' };
+    this.credit = this.add
+      .text(40, VIRTUAL_HEIGHT, 'DIRECTOR  DAINEI MAKINO', style)
+      .setOrigin(0, 0.5)
+      .setDepth(1001)
+      .setAlpha(0);
+    this.tweens.add({ targets: this.credit, alpha: 1, duration: 500 });
+
+    this.time.delayedCall(10000, () => {
+      evaporateArea(
+        this,
+        this.credit.x,
+        this.credit.y - this.credit.height / 2,
+        this.credit.width,
+        this.credit.height,
+        0xffffff
+      );
+      this.credit.destroy();
+      this.restartGame();
+    });
+  }
+
+  restartGame() {
+    this.scene.stop('GameScene');
+    this.scene.stop('UIScene');
+    gameState.reset();
+    this.scene.start('GameScene');
+    this.scene.launch('UIScene');
+    this.scene.bringToTop('UIScene');
+    this.scene.stop();
+  }
+}

--- a/src/game.js
+++ b/src/game.js
@@ -11,6 +11,7 @@ import { newChunkTransition, evaporateArea, spawnAfterimage } from './effects.js
 import LoadingScene from './loading_scene.js';
 import StarField from './star_field.js';
 import GameOverScene from './game_over_scene.js';
+import EndingScene from './ending_scene.js';
 import { computeTetherPoints, isHorizontal, isVertical } from './utils.js';
 import Shield from './shield.js';
 import MeteorField from './meteor_field.js';
@@ -103,6 +104,11 @@ class GameScene extends Phaser.Scene {
     this.rivalPauseTimer = null;
     this.rivalPaused = false;
     this.lastRivalSpikeTile = null;
+
+    // Re-enable controls when restarting the game
+    this.controlsDisabled = false;
+    this.endingTarget = null;
+    this.pendingEnding = null;
 
     this.hero = new HeroState();
     this.isMoving = false;
@@ -1309,6 +1315,9 @@ class GameScene extends Phaser.Scene {
       this.heroImage.setFlipX(false);
       this.hero.direction = 'down';
       this.endingTarget = null;
+      this.scene.launch('EndingScene');
+      this.scene.bringToTop('EndingScene');
+      this.scene.pause();
       return;
     }
     const dir = this._nextHeroDirToward(this.endingTarget.x, this.endingTarget.y);
@@ -1479,7 +1488,7 @@ const config = {
     width: VIRTUAL_WIDTH * 2,
     height: VIRTUAL_HEIGHT * 2
   },
-  scene: [LoadingScene, GameScene, UIScene, GameOverScene]
+  scene: [LoadingScene, GameScene, UIScene, GameOverScene, EndingScene]
 };
 
 Characters.ready.then(() => {


### PR DESCRIPTION
## Summary
- implement `EndingScene` to display ending messages and credit
- trigger the ending when the hero reaches the center of the final chunk
- zoom out the camera and fade between messages
- register `EndingScene` in the game configuration
- reset the game after credits roll
- ensure controls work again when restarting after the ending

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68879a8232ec8333903e09b8ee183c03