### PR TITLE
Implement slow zoom out in ending scene

### DIFF
--- a/src/ending_scene.js
+++ b/src/ending_scene.js
@@ -34,8 +34,16 @@ export default class EndingScene extends Phaser.Scene {
 
     const gameScene = this.scene.get('GameScene');
     if (gameScene && gameScene.cameraManager) {
-      // Gradually zoom out over the entire ending sequence
-      gameScene.cameraManager.setZoom(0.6, 20000);
+      // Gradually zoom out over the entire ending sequence.
+      // The GameScene is paused, so create the tween on this scene
+      // and manually update the camera manager's default zoom.
+      gameScene.cameraManager.defaultZoom = 0.6;
+      this.tweens.add({
+        targets: gameScene.cameras.main,
+        zoom: 0.6,
+        duration: 20000,
+        ease: 'Sine.easeInOut'
+      });
     }
 
     this.time.delayedCall(10000, () => {


### PR DESCRIPTION
## Summary
- extend camera zoom out time in the ending scene

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887a0af094c8333a0109d987c78566c