### PR TITLE
Consume key on exit

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -392,7 +392,7 @@ class GameScene extends Phaser.Scene {
               (tileInfo.cell === TILE.WALL ||
                 tileInfo.cell === TILE.REACTOR ||
                 (tileInfo.cell === TILE.SILVER_DOOR && this.hero.keys === 0) ||
-                (tileInfo.cell === TILE.DOOR && this.hero.keys === 0 && !tileInfo.chunk.chunk.exited && !tileInfo.chunk.chunk.doorOpen) ||
+                (tileInfo.cell === TILE.DOOR && this.hero.keys === 0 && !tileInfo.chunk.chunk.exited) ||
                 (tileInfo.cell === TILE.AUTO_GATE &&
                   tileInfo.chunk.chunk.autoGates &&
                   tileInfo.chunk.chunk.autoGates.find(
@@ -603,9 +603,11 @@ class GameScene extends Phaser.Scene {
       }
 
       if (curTile.cell === TILE.DOOR && !curTile.chunk.chunk.exited) {
-        if (curTile.chunk.chunk.doorOpen || this.hero.useKey()) {
-          this.mazeManager.openDoor(curTile.chunk);
-          this.playSound('door_open');
+        if (this.hero.useKey()) {
+          if (!curTile.chunk.chunk.doorOpen) {
+            this.mazeManager.openDoor(curTile.chunk);
+            this.playSound('door_open');
+          }
           this.cameraManager.zoomHeroFocus();
           curTile.chunk.chunk.exited = true;
           gameState.incrementMazeCount();


### PR DESCRIPTION
## Summary
- require a key even when exit doors are already open
- spend a key each time the hero passes through an exit door

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887aa0d1768833385278b6bc6c002ad