### PR TITLE
Allow open doors to be passed without keys

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -392,7 +392,7 @@ class GameScene extends Phaser.Scene {
               (tileInfo.cell === TILE.WALL ||
                 tileInfo.cell === TILE.REACTOR ||
                 (tileInfo.cell === TILE.SILVER_DOOR && this.hero.keys === 0) ||
-                (tileInfo.cell === TILE.DOOR && this.hero.keys === 0 && !tileInfo.chunk.chunk.exited) ||
+                (tileInfo.cell === TILE.DOOR && this.hero.keys === 0 && !tileInfo.chunk.chunk.doorOpen && !tileInfo.chunk.chunk.exited) ||
                 (tileInfo.cell === TILE.AUTO_GATE &&
                   tileInfo.chunk.chunk.autoGates &&
                   tileInfo.chunk.chunk.autoGates.find(
@@ -603,7 +603,7 @@ class GameScene extends Phaser.Scene {
       }
 
       if (curTile.cell === TILE.DOOR && !curTile.chunk.chunk.exited) {
-        if (this.hero.useKey()) {
+        if (curTile.chunk.chunk.doorOpen || this.hero.useKey()) {
           if (!curTile.chunk.chunk.doorOpen) {
             this.mazeManager.openDoor(curTile.chunk);
             this.playSound('door_open');


### PR DESCRIPTION
## Summary
- avoid blocking hero when a door starts already open
- let hero walk through initially open doors without consuming a key

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887abcf0cd0833393c4e44f0ed1195e