### PR TITLE
Disable debug chunk HUD and controls

### DIFF
--- a/src/debug_flags.js
+++ b/src/debug_flags.js
@@ -1,1 +1,3 @@
-export const DEBUG_CHUNK_COUNTER = true; // Toggle chunk counter overlay
+// Debug overlay to manually modify chunk counts and display them.
+// Disabled by default so players cannot access it.
+export const DEBUG_CHUNK_COUNTER = false;


### PR DESCRIPTION
## Summary
- disable debug chunk controls and counter by default via `DEBUG_CHUNK_COUNTER`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887ac666bd48333b6ad5f876f5ec54f