### PR TITLE
Lower master volume

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -24,8 +24,8 @@ const MIDPOINTS = [1, 5, 10, 15, 20, 30, 40, 50];
 const VIRTUAL_WIDTH = 480;
 const VIRTUAL_HEIGHT = 270;
 
-// Master volume applied to all sounds (40%)
-const MASTER_VOLUME = 0.4;
+// Master volume applied to all sounds (30%)
+const MASTER_VOLUME = 0.3;
 
 // Global state for tracking overall game progress
 


### PR DESCRIPTION
## Summary
- tone down MASTER_VOLUME constant to 30%

## Testing
- `grep -n "MASTER_VOLUME" -n src/game.js`

------
https://chatgpt.com/codex/tasks/task_e_68889c0ee4988333acac8b4d5671b888